### PR TITLE
Initial implementation of commit-push-and-tag-release action

### DIFF
--- a/commit-push-and-tag-release/Dockerfile
+++ b/commit-push-and-tag-release/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache git bash git-subtree
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/commit-push-and-tag-release/README.md
+++ b/commit-push-and-tag-release/README.md
@@ -1,0 +1,23 @@
+# Commit Push and Tag Release
+This action commits the file according to the `add` argument and pushes it to your repository.
+
+This action is specifically tailored to run *on* a PR after it is closed and merged so it may not work as intended if it runs straight from a regular commit/push.
+
+## Requirements
+You must specify the file you want pushed to your repository as an `add` argument and also expose your `GITHUB_TOKEN`.
+
+# Usage
+```yaml
+jobs:
+  job_name:
+    name: Job Name
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Commit Push and Tag Release
+      uses: thefrontside/actions/commit-push-and-tag-release@master
+      with:
+        add: package.json
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```

--- a/commit-push-and-tag-release/entrypoint.sh
+++ b/commit-push-and-tag-release/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
+
+branch=$(printf "%s\n" "${GITHUB_BASE_REF#*refs\/heads\/}")
+git checkout $branch
+
+echo branch: $branch
+
+git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+git config user.name "$GITHUB_ACTOR"
+
+git add $INPUT_ADD
+
+current="`node -e \"console.log(require('./package.json').version)\"`"
+git commit -m "Release version $current"
+git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" $branch


### PR DESCRIPTION
# Purpose
The purpose of this PR is to introduce the `commit-push-and-tag-release` action. The commit-and-push action already exists in the actions marketplace, but it does not allow the user to be explicit in which file they want committed. If down the road we're okay with committing all changes, we will no longer need this action.

# Approach
This action is used in our Github Actions workflow for when PR is merged. As part of the workflow the version in `package.json` is updated in preparation for automated publishing. The `commit-push-and-tag-release` action allows the workflow to automatically commit/push the changes to the repository.
<img width="685" alt="commit-push-and-tag-release" src="https://user-images.githubusercontent.com/29791650/65449140-55acbf80-de08-11e9-8c48-4488950f38fd.png">
# Usage
- You must expose the `GITHUB_TOKEN`.
- You must specify the file you want committed as `with: add:` as shown below.
```yaml
steps:
- name: Commit Push and Tag Release
  uses: thefrontside/actions/commit-push-and-tag-release@master
  with:
    add: package.json
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```