### PR TITLE
Implement publish-pr-preview to refactor workflow into one action

### DIFF
--- a/npm-publish-branch-preview/entrypoint.sh
+++ b/npm-publish-branch-preview/entrypoint.sh
@@ -23,5 +23,6 @@ else
   echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
   npm config set unsafe-perm true
   npm install
-  npm publish --access=public --tag $GITHUB_HEAD_REF
-fi
+  tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
+  npm publish --access=public --tag $tag
+fi`

--- a/npm-publish-branch-preview/entrypoint.sh
+++ b/npm-publish-branch-preview/entrypoint.sh
@@ -21,5 +21,7 @@ elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
     exit 1
 else
   echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+  npm config set unsafe-perm true
+  npm install
   npm publish --access=public --tag $GITHUB_HEAD_REF
 fi

--- a/npm-publish-branch-preview/entrypoint.sh
+++ b/npm-publish-branch-preview/entrypoint.sh
@@ -25,4 +25,4 @@ else
   npm install
   tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
   npm publish --access=public --tag $tag
-fi`
+fi

--- a/publish-pr-preview/Dockerfile
+++ b/publish-pr-preview/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache git bash git-subtree
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -1,0 +1,25 @@
+# Publish PR Preview
+This action will:
+- Check for accessibility to NPM token in secrets.
+- Make sure this action is being run from a pull request.
+- Make sure the name of the head branch of the pull request isn't `latest` to avoid conflicts with NPM tagging.
+- Update package version with snapshot, publish to NPM with branch name as tag.
+- Comment on pull request with instructions on how to access the package.
+
+## Requirements
+You must pass in your `GITHUB_TOKEN` and `NPM_AUTH_TOKEN`. Remember to add `NPM_AUTH_TOKEN` in your repository secrets.
+
+## Usage
+```yaml
+jobs:
+  job_name:
+    name: Job Name
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+```

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -30,14 +30,19 @@ const { markdown } = require('danger');
 const pjson = require('./package.json');
 
 const current = `https://www.npmjs.com/package/${pjson.name}/v/${pjson.version}`
+const branch = process.env.GITHUB_HEAD_REF;
+const masked = branch.replace(/\//g, '_');
 
-
-const first_line = `This PR is available to use:`
 const install_version = `npm install ${pjson.name}@${pjson.version}`;
-const install_tag = `npm install ${pjson.name}@${process.env.GITHUB_HEAD_REF}`;
-const last_line = `You can view the NPM package [here](${current}).`
 
-markdown(`${first_line}\n\`\`\`bash\n${install_version}\n\`\`\`\nor\n\`\`\`bash\n${install_tag}\n\`\`\`\n${last_line}`)
+const first_line = `A preview package of this pull request has been released to NPM with the tag \`${masked}\`.`;
+const second_line = `You can try it out by running the following command:`;
+const install_tag = `$ npm install ${pjson.name}@${masked}`;
+const fourth_line = `or by updating your package.json to:`
+const update_json = `\{\n  \"${pjson.name}\": \"${masked}\"\n\}`
+const last_line = `Once the branch associated with this tag is deleted (usually once the PR is merged or closed), it will no longer be available. However, it currently references [${pjson.name}@${pjson.version}](${current}) which will be available to install forever.`;
+
+markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
 EOT
   yarn global add danger --dev
   export PATH="$(yarn global bin):$PATH"

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -e
+IFS=$'\n\t'
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
+  then
+    echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
+    echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+    exit 1
+elif [[ "$GITHUB_HEAD_REF" = "" ]]
+  then
+    echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
+    exit 1
+elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
+  then
+    echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
+    echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
+    exit 1
+else
+  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+  npm publish --access=public --tag $GITHUB_HEAD_REF
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+const pjson = require('./package.json');
+
+const current = `https://www.npmjs.com/package/${pjson.name}/v/${pjson.version}`
+
+
+const first_line = `This PR is available to use:`
+const install_version = `npm install ${pjson.name}@${pjson.version}`;
+const install_tag = `npm install ${pjson.name}@${process.env.GITHUB_HEAD_REF}`;
+const last_line = `You can view the NPM package [here](${current}).`
+
+markdown(`${first_line}\n\`\`\`bash\n${install_version}\n\`\`\`\nor\n\`\`\`bash\n${install_tag}\n\`\`\`\n${last_line}`)
+EOT
+  yarn global add danger --dev
+  export PATH="$(yarn global bin):$PATH"
+  danger ci
+fi

--- a/synchronize-npm-tags/Dockerfile
+++ b/synchronize-npm-tags/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache git bash git-subtree
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["sh", "/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/synchronize-npm-tags/entrypoint.sh
+++ b/synchronize-npm-tags/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 IFS=$'\n\t'
 

--- a/synchronize-npm-tags/entrypoint.sh
+++ b/synchronize-npm-tags/entrypoint.sh
@@ -1,27 +1,33 @@
 #!/bin/sh
 set -e
-IFS=$'\n\t' #required for checking tag against user argument
+IFS=$'\n\t'
 
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
-BLUE='\033[1;34m'
 NC='\033[0m'
 
-package="`node -e \"console.log(require('./package.json').name)\"`"
-branches="$(git ls-remote --heads origin  | sed 's?.*refs/heads/??')"
-npmtags=$(npm dist-tag ls | sed 's/\:.*//')
+package="`node -e \"console.log(require('./package.json').name)\"`";
+input_encoded="$(echo $INPUT_PRESERVE | sed -E 's:_:__:g;s:\/:_:g')"
+declare -a input_arrayed=($(echo $input_encoded | tr " " "\n"))
+branches="$(git ls-remote --heads origin  | sed 's?.*refs/heads/??')";
+branches_encoded="$(echo $branches | sed -E 's:_:__:g;s:\/:_:g')";
+declare -a branches_arrayed=($(echo $branches_encoded | tr " " "\n"));
+npmtags=$(npm dist-tag ls | sed 's/:.*//');
 
 for tag in $npmtags; do
-  if [[ "$tag" = "latest" ]] || [[ $(echo "$INPUT_KEEP" | grep -e "$tag") ]]
+  if [[ "$tag" = "latest" ]]
     then
-      echo -e "${RED}$tag${GREEN}: Keeping protected tag.${NC}"
-  elif [[ $(echo $branches | grep -e "$tag") ]]
+      echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because it is protected.${NC}"
+  elif [[ $(echo $(for branch in ${branches_arrayed[@]}; do if [[ "$branch" = "$tag" ]]; then echo "$tag"; fi; done;)) ]]
     then
-      echo -e "${RED}$tag${GREEN}: Keeping tag because we found a matching branch.${NC}"
+      echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because we found a matching branch.${NC}"
+  elif [[ $(echo $(for arg in ${input_arrayed[@]}; do if [[ "$arg" = "$tag" ]]; then echo "$tag"; fi; done;)) ]]
+    then
+      echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because it is protected.${NC}"
   else
     echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
     npm dist-tag rm $package $tag
-    echo -e "${RED}$tag${YELLOW}: Removed tag from NPM because it did not match any existing branches.${NC}"
+    echo -e "${RED}Removed tag, ${YELLOW}$tag${RED} from NPM because it did not match any existing branches.${NC}"
   fi
 done

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -30,6 +30,8 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+        npm config set unsafe-perm true
+        npm install
         npm publish --access=public
         
         echo -e "${GREEN}Tagged and published version v${version} successfully!${NC}"

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -26,8 +26,8 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
         git config user.name "$GITHUB_ACTOR"
         
-        git tag -f "v$version"
-        git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag
+        git tag --force "v$version"
+        git push --force  --tags "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
         npm config set unsafe-perm true


### PR DESCRIPTION
## Motivation
Currently, Github does not provide a way to upload workflows to be reusable in multiple projects; the workflows must be manually configured for each project.

The `npm-publish-branch-preview` action is dependent on `write-npm-snapshot-version` to provide it with a unique package version number otherwise the publishing will result in an error. And `post-npm-usage-instructions-comment` is irrelevant without the first two actions.

The proposal is to combine the three actions into one. The new `publish-pr-preview` action will make it much easier to maintain/modify the workflow without having to jump between different actions to see if one update of an action breaks the functionality of other actions.

Please see [Criteria](#Criteria) below to see what needs to be addressed before this PR can be taken out of draft status.

## Approach
The flow of this action is as follows:
- Check for access to NPM token in secrets.
- Make sure this action is being run from a pull request.
- Make sure the name of the head branch of the pull request isn't `latest` to avoid conflicts with NPM tagging.
- Update package version with snapshot.
- Publish to NPM with branch name as tag.
- Comment on pull request with instructions on how to access the package.

This action will allow the entire workflow to look like this:
```yml
jobs:
  publish: 
    name: Publish PR Preview
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - name: Publish PR Preview
      uses: thefrontside/actions/publish-pr-preview@master
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
```
Previous workflow with the three actions looked like this:
```yml
jobs:
  preview: 
    name: Publish Preview Package
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - name: Write NPM Snapshot Version
      uses: thefrontside/actions/write-npm-snapshot-version@master
    - name: NPM Publish Commit
      uses: thefrontside/actions/npm-publish-branch-preview@master
      env:
        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
    - name: Post Instructions Comment
      uses: thefrontside/actions/post-npm-usage-instructions-comment@master
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
```

## Trade-offs
- I can't think of any scenarios at the moment but this approach limits our usability of `GITHUB_TOKEN`. For example, we wouldn't be able to get github-actions bot to perform one action and a separate custom bot to perform another if they both utilize `GITHUB_TOKEN`. Perhaps there are no cases where two bots are needed?
- Customization. Can't predict this to be an issue yet because it suits our needs and its functions are straightforward, but other teams/projects might have different criteria for their pull requests.

## Criteria
- [x] Update message content to include instructions on how to install package using tags? See [issue #14](https://github.com/thefrontside/actions/issues/14).
- [x] Test run the current `publish-preview` workflow on `microstates.js` to see if anything else should be added.
- [x] Maybe run the current setup on `Effection`/`Bigtest` too before we consider adapting this new action.

## Learning
- This action was tested on [minkimcello/georgia](https://github.com/minkimcello/georgia/pull/11).