### PR TITLE
Allow running of npm scripts on GitHub docker containers

### DIFF
--- a/npm-publish-branch-preview/entrypoint.sh
+++ b/npm-publish-branch-preview/entrypoint.sh
@@ -21,5 +21,7 @@ elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
     exit 1
 else
   echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+  npm config set unsafe-perm true
+  npm install
   npm publish --access=public --tag $GITHUB_HEAD_REF
 fi

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -30,6 +30,8 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+        npm config set unsafe-perm true
+        npm install
         npm publish --access=public
         
         echo -e "${GREEN}Tagged and published version v${version} successfully!${NC}"


### PR DESCRIPTION
# Motivation

Our npm publishing was not working because it was skipping the lifecycle hooks like `prepare`, `prepack`, `prepublish`, etc... This was happening because the github actions are running as root on the docker container, but `npm` opts out of lifecycle hooks when running as root for security reasons.

# Approach
This change sets the `unsafe-perm` npm configuration parameter which opts in to potentially dangerous operations like lifecycle hooks when running as root.

> Note: It's ok for these operations to run as root in this case because the whole docker container exists only to publish an npm package.

This actually uncovered a separate problem where we were not installing dependencies needed to actually run the lifecycle hooks. For example, the `prepack` hook for microstates does an `npm build`, but the build requires rollup.

As a result, an npm install is performed before all npm operations.