### PR TITLE
Add force tag to git push in

### DIFF
--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -27,7 +27,7 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git config user.name "$GITHUB_ACTOR"
         
         git tag -f "v$version"
-        git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag
+        git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag -f
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
         npm config set unsafe-perm true

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -27,7 +27,7 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git config user.name "$GITHUB_ACTOR"
         
         git tag --force "v$version"
-        git push --force  --tag "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+        git push --force  --tags "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
         npm config set unsafe-perm true

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -27,7 +27,7 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git config user.name "$GITHUB_ACTOR"
         
         git tag --force "v$version"
-        git push --force "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag
+        git push --force  --tag "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
         npm config set unsafe-perm true

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -26,8 +26,8 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
         git config user.name "$GITHUB_ACTOR"
         
-        git tag -f "v$version"
-        git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag -f
+        git tag --force "v$version"
+        git push --force "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git" --tag
 
         echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
         npm config set unsafe-perm true


### PR DESCRIPTION
We were missing a force tag on `git push --tag` for `synchronize-with-npm` action to overwrite tags.