### PR TITLE
Implement tag-encoding to avoid npm errors

### DIFF
--- a/npm-publish-branch-preview/entrypoint.sh
+++ b/npm-publish-branch-preview/entrypoint.sh
@@ -23,5 +23,6 @@ else
   echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
   npm config set unsafe-perm true
   npm install
-  npm publish --access=public --tag $GITHUB_HEAD_REF
+  tag="$(echo $GITHUB_HEAD_REF | sed -E 's/\_+/&\_/g;s/\//\_/g')"
+  npm publish --access=public --tag $tag
 fi

--- a/synchronize-npm-tags/entrypoint.sh
+++ b/synchronize-npm-tags/entrypoint.sh
@@ -8,20 +8,22 @@ YELLOW='\033[1;33m'
 BLUE='\033[1;34m'
 NC='\033[0m'
 
-package="`node -e \"console.log(require('./package.json').name)\"`"
-branches="$(git ls-remote --heads origin  | sed 's?.*refs/heads/??')"
-npmtags=$(npm dist-tag ls | sed 's/\:.*//')
+package="`node -e \"console.log(require('./package.json').name)\"`";
+input_keep_encoded="$(echo $INPUT_KEEP | sed -E 's/\_+/&\_/g;s/\//\_/g')"
+branches="$(git ls-remote --heads origin  | sed 's?.*refs/heads/??')";
+branches_encoded="$(echo $branches | sed -E 's/\_+/&\_/g;s/\//\_/g')";
+npmtags=$(npm dist-tag ls | sed 's/\:.*//');
 
 for tag in $npmtags; do
-  if [[ "$tag" = "latest" ]] || [[ $(echo "$INPUT_KEEP" | grep -e "$tag") ]]
+  if [[ "$tag" = "latest" ]] || [[ $(echo "$input_keep_encoded" | grep -e "$tag") ]]
     then
-      echo -e "${RED}$tag${GREEN}: Keeping protected tag.${NC}"
-  elif [[ $(echo $branches | grep -e "$tag") ]]
+      echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because it is protected.${NC}"
+  elif [[ $(echo $branches_encoded | grep -e "$tag") ]]
     then
-      echo -e "${RED}$tag${GREEN}: Keeping tag because we found a matching branch.${NC}"
+      echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because we found a matching branch.${NC}"
   else
     echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
     npm dist-tag rm $package $tag
-    echo -e "${RED}$tag${YELLOW}: Removed tag from NPM because it did not match any existing branches.${NC}"
+    echo -e "${RED}Removed tag, ${YELLOW}$tag${RED} from NPM because it did not match any existing branches.${NC}"
   fi
 done


### PR DESCRIPTION
## Motivation
Part of our publishing process involves publishing pull request packages to NPM using branch names as tags. This allows us to install and test new changes of a pull request without having to wait for approval & merge. However, installing packages with tags that have slashes in them confuses the NPM CLI so this PR is to introduce a workaround.

## Approach
### npm-publish-branch-preview
The `thefrontside/actions/npm-publish-branch-preview` action will publish to NPM with the head branch name as its tag. The new proposed changes will encode the branch name so that all instances of `/` are replaced with `_` as well as adding an additional `_` after each group of `_` if branch already has those characters in its name (i.e. one underscore would become two; four underscores would become five).

Examples:
- `mk/branch_name` will be encoded as `mk_branch__name`
- `mk_branch__name` will become `mk__branch___name`

### synchronize-npm-tags
This action has also been updated to adapt to the tag-encoding. This action, which runs on our `on-delete` workflow, will retrieve all the tags from NPM (which are already encoded from `npm-publish-branch-preview`) to cross check them with branch names of the Github repository; it's so that we can remove unnecessary NPM tags once a branch is deleted.

With the new update, this action will encode branch names and user-specified argument (to preserve tags that do not have corresponding branches) in the same manner as how it was encoded in `npm-publish-branch-preview`.

## Conclusion
In summary, this encoding only happens before publishing tags *to* NPM and as it makes checks to see which ones to remove *from* NPM so it should not cause any issues elsewhere.