### PR TITLE
Use bash

### DIFF
--- a/synchronize-with-npm/Dockerfile
+++ b/synchronize-with-npm/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache git bash git-subtree
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["sh", "/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]


### PR DESCRIPTION
In order to make the command `npm run pack:publish` work as a variable, `bash` is needed since `sh` will look for the command as a single entity, spaces and all (which of course does not exist)