### PR TITLE
Don't change input field separator

### DIFF
--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
-IFS=$'\n\t'
 
 RED='\033[1;31m'
 GREEN='\033[1;32m'


### PR DESCRIPTION
In bash the IFS is used to determine what constitutes a word boundary, and normally it consists of all whitespace characters. By setting it to not include spaces, it will not recognize `npm run pack:publish` as the `npm` command plus its arguments, and instead will think the whole string is the command which, of course, does not exist.

This removes the override and let's word separation to proceed normally.