### PR TITLE
Revert two actions back to shell from bash

### DIFF
--- a/synchronize-npm-tags/Dockerfile
+++ b/synchronize-npm-tags/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache git bash git-subtree
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["bash", "/entrypoint.sh"]
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/synchronize-npm-tags/entrypoint.sh
+++ b/synchronize-npm-tags/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 RED='\033[1;31m'
@@ -12,14 +12,14 @@ branches="$(git ls-remote --heads origin  | sed 's?.*refs/heads/??')";
 branches_encoded="$(echo $branches | sed -E 's:_:__:g;s:\/:_:g')";
 npmtags=$(npm dist-tag ls | sed 's/:.*//');
 
-for tag in ${npmtags[@]}; do
+for tag in $npmtags; do
   if [[ "$tag" = "latest" ]]
     then
       echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because it is protected.${NC}"
-  elif [[ $(echo $(for branch in ${branches_encoded[@]}; do if [[ "$branch" = "$tag" ]]; then echo "$tag"; fi; done;)) ]]
+  elif [[ $(echo $(for branch in $branches_encoded; do if [[ "$branch" = "$tag" ]]; then echo "$tag"; fi; done;)) ]]
     then
       echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because we found a matching branch.${NC}"
-  elif [[ $(echo $(for arg in ${input_encoded[@]}; do if [[ "$arg" = "$tag" ]]; then echo "$tag"; fi; done;)) ]]
+  elif [[ $(echo $(for arg in $input_encoded; do if [[ "$arg" = "$tag" ]]; then echo "$tag"; fi; done;)) ]]
     then
       echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because it is protected.${NC}"
   else

--- a/write-npm-snapshot-version/entrypoint.sh
+++ b/write-npm-snapshot-version/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version


### PR DESCRIPTION
I struggled to loop through a string in shell script and a few stackoverflow posts mentioned shell doesn't have a way of declaring arrays.

Turns out the reason why I had trouble looping was because of the custom-set IFS and all the workarounds I created to that IFS.

I've tested both [`synchronize-npm-tags`](https://github.com/minkimcello/georgia/commit/dc711ef0f35c661ef23b459ec8dd5d4fb432e5e5/checks?check_suite_id=271640678) and [`write-npm-snapshot-version`](https://github.com/minkimcello/georgia/commit/826060f6681e6583d12aa01e71dd672f14ab42d1/checks?check_suite_id=269989806) on `minkimcello/georgia` to confirm they work as intended in shell.