### PR TITLE
Refactor preview publish actions into one action

### DIFF
--- a/publish-pr-preview/Dockerfile
+++ b/publish-pr-preview/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache git bash git-subtree
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -1,0 +1,28 @@
+# Publish PR Preview
+This action will:
+- Check for accessibility to NPM token in secrets.
+- Make sure this action is being run from a pull request.
+- Make sure the name of the head branch of the pull request isn't `latest` to avoid conflicts with NPM tagging.
+- Update package version with snapshot, publish to NPM with branch name as tag.
+- Comment on pull request with instructions on how to access the package.
+
+## Requirements
+- Pass in `GITHUB_TOKEN` and `NPM_AUTH_TOKEN`.
+- Optional: `NPM_PUBLISH` argument is available if you want to run a different command. `npm publish` will run as default.
+
+## Usage
+```yaml`
+jobs:
+  job_name:
+    name: Job Name
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@master
+      with:
+        NPM_PUBLISH: npm run my-script
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+```

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -e
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
+  then
+    echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
+    echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+    exit 1
+elif [[ "$GITHUB_HEAD_REF" = "" ]]
+  then
+    echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
+    exit 1
+elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
+  then
+    echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
+    echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
+    exit 1
+else
+  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+  npm config set unsafe-perm true
+  npm install
+  tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
+  if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]
+    then
+      npm publish --access=public --tag $tag
+    else
+      $INPUT_NPM_PUBLISH --access=public --tag $tag
+  fi
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+const pjson = require('./package.json');
+
+const current = `https://www.npmjs.com/package/${pjson.name}/v/${pjson.version}`
+const branch = process.env.GITHUB_HEAD_REF;
+const masked = branch.replace(/\//g, '_');
+
+const install_version = `npm install ${pjson.name}@${pjson.version}`;
+
+const first_line = `A preview package of this pull request has been released to NPM with the tag \`${masked}\`.`;
+const second_line = `You can try it out by running the following command:`;
+const install_tag = `$ npm install ${pjson.name}@${masked}`;
+const fourth_line = `or by updating your package.json to:`
+const update_json = `\{\n  \"${pjson.name}\": \"${masked}\"\n\}`
+const last_line = `Once the branch associated with this tag is deleted (usually once the PR is merged or closed), it will no longer be available. However, it currently references [${pjson.name}@${pjson.version}](${current}) which will be available to install forever.`;
+
+markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
+EOT
+
+yarn global add danger --dev
+export PATH="$(yarn global bin):$PATH"
+danger ci
+fi


### PR DESCRIPTION
Did an oopsy with rebasing/commits on the original PR so I just made a new PR on a new branch but you can see the old discussion [here](https://github.com/thefrontside/actions/pull/15).

## Motivation
Currently, Github does not provide a way to upload workflows to be reusable in multiple projects; the workflows must be manually configured for each project.

The `npm-publish-branch-preview` action is dependent on `write-npm-snapshot-version` to provide it with a unique package version number otherwise the publishing will result in an error. And `post-npm-usage-instructions-comment` is irrelevant without the first two actions.

The proposal is to combine the three actions into one. The new `publish-pr-preview` action will make it much easier to maintain/modify the workflow without having to jump between different actions to see if one update of an action breaks the functionality of other actions.

## Approach
The flow of this action is as follows:
- Check for access to NPM token in secrets.
- Make sure this action is being run from a pull request.
- Make sure the name of the head branch of the pull request isn't `latest` to avoid conflicts with NPM tagging.
- Update package version with snapshot.
- Publish to NPM with branch name as tag.
  - With option to specify `NPM_PUBLISH` arg for specific build/publish needs
- Comment on pull request with instructions on how to access the package.

This action will allow the entire workflow to look like this:
```yml
jobs:
  publish: 
    name: Publish PR Preview
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - name: Publish PR Preview
      uses: thefrontside/actions/publish-pr-preview@master
      with:
        NPM_PUBLISH: npm run my:script
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
```
Previous workflow with the three actions looked like this:
```yml
jobs:
  preview: 
    name: Publish Preview Package
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - name: Write NPM Snapshot Version
      uses: thefrontside/actions/write-npm-snapshot-version@master
    - name: NPM Publish Commit
      uses: thefrontside/actions/npm-publish-branch-preview@master
      with:
        NPM_PUBLISH: npm run my:script
      env:
        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
    - name: Post Instructions Comment
      uses: thefrontside/actions/post-npm-usage-instructions-comment@master
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_POST_COMMENT_TOKEN }}
```

## TODOs
There are no TODOs to merge this PR but once merged I'll update all the workflows to use this action so that I can deprecate the three actions.

## Tests
- [PR #27](https://github.com/minkimcello/georgia/pull/27) to demonstrate generating comment still works
- [Successful run of the action](https://github.com/minkimcello/georgia/commit/8169628aa4f4b7067c531b47e9a4c502ed9270ed/checks?check_suite_id=276232800)
- [Running on branch 'latest' to trigger error](https://github.com/minkimcello/georgia/commit/d33a2f68273f3f8e69fab7bd238c99d3f9e3f04f/checks?check_suite_id=276240928)
- [Running action on non-pr to trigger error](https://github.com/minkimcello/georgia/commit/6e2b46c39d7876f29d1954f65cce45a7e817ddf8/checks?check_suite_id=276244015)
- [Running with no NPM token to trigger error](https://github.com/minkimcello/georgia/commit/2de040eb324c6a4fd1e5c7a8a9a8d096f1066db8/checks?check_suite_id=276236593)