### PR TITLE
Remove exit codes and add custom messages for previews

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -6,10 +6,16 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
+if [[ "$GITHUB_HEAD_REF" = "" ]]
   then
-    echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
-    echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+    echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
+    exit 1
+
+else
+  if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
+    then
+      echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
+      echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
     
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
@@ -20,19 +26,10 @@ const second_line = `Publishing preview will not work if the pull request was cr
 markdown(`${first_line}\n\n${second_line}`)
 EOT
 
-    yarn global add danger --dev
-    export PATH="$(yarn global bin):$PATH"
-    danger ci
-
-elif [[ "$GITHUB_HEAD_REF" = "" ]]
-  then
-    echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
-    exit 1
-    
-elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
-  then
-    echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
-    echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
+  elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
+    then
+      echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
+      echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
 
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
@@ -43,22 +40,18 @@ const second_line = `Please change the name of your branch and resubmit the pull
 markdown(`${first_line}\n\n${second_line}`)
 EOT
 
-    yarn global add danger --dev
-    export PATH="$(yarn global bin):$PATH"
-    danger ci
-
-else
-  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-  echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
-  npm config set unsafe-perm true
-  npm install
-  tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
-  if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]
-    then
-      npm publish --access=public --tag $tag
-    else
-      $INPUT_NPM_PUBLISH --access=public --tag $tag
-  fi
+  else
+    npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+    echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+    npm config set unsafe-perm true
+    npm install
+    tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
+    if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]
+      then
+        npm publish --access=public --tag $tag
+      else
+        $INPUT_NPM_PUBLISH --access=public --tag $tag
+    fi
 
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
@@ -79,6 +72,8 @@ const last_line = `Once the branch associated with this tag is deleted (usually 
 
 markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
 EOT
+
+  fi
 
   yarn global add danger --dev
   export PATH="$(yarn global bin):$PATH"

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -20,8 +20,8 @@ else
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 
-const first_line = `ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.`;
-const second_line = `Please change the name of your branch and resubmit the pull request.`;
+const first_line = `:warning: WARNING :warning:`;
+const second_line = `We didn't publish this tag to NPM because it would conflict with the reserved \`latest\` tag.`;
 
 markdown(`${first_line}\n\n${second_line}`)
 EOT
@@ -34,8 +34,8 @@ EOT
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 
-const first_line = `ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.`;
-const second_line = `Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.`;
+const first_line = `:mega: Heads up!`;
+const second_line = `I didn't detect an NPM_AUTH_TOKEN which is necessary to publish a preview version of this package, and so I wasn't able to. However, this is perfectly normal for pull requests that are submitted from a forked repository.`;
 
 markdown(`${first_line}\n\n${second_line}`)
 EOT

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -21,7 +21,7 @@ cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 
 const first_line = `:warning: WARNING :warning:`;
-const second_line = `We didn't publish this tag to NPM because it would conflict with the reserved \`latest\` tag.`;
+const second_line = `I can't publish a preview of this branch this because it would conflict with \`latest\` tag which is [reserved by NPM](https://docs.npmjs.com/cli/dist-tag#purpose).`;
 
 markdown(`${first_line}\n\n${second_line}`)
 EOT

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -10,16 +10,43 @@ if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
   then
     echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
     echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
-    exit 1
+    
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+
+const first_line = `ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.`;
+const second_line = `Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+
+    yarn global add danger --dev
+    export PATH="$(yarn global bin):$PATH"
+    danger ci
+
 elif [[ "$GITHUB_HEAD_REF" = "" ]]
   then
     echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
     exit 1
+    
 elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
   then
     echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
     echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
-    exit 1
+
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+
+const first_line = `ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.`;
+const second_line = `Please change the name of your branch and resubmit the pull request.`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+
+    yarn global add danger --dev
+    export PATH="$(yarn global bin):$PATH"
+    danger ci
+
 else
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
@@ -32,6 +59,7 @@ else
     else
       $INPUT_NPM_PUBLISH --access=public --tag $tag
   fi
+
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 const pjson = require('./package.json');
@@ -52,7 +80,8 @@ const last_line = `Once the branch associated with this tag is deleted (usually 
 markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
 EOT
 
-yarn global add danger --dev
-export PATH="$(yarn global bin):$PATH"
-danger ci
+  yarn global add danger --dev
+  export PATH="$(yarn global bin):$PATH"
+  danger ci
+
 fi

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -21,7 +21,7 @@ cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 
 const first_line = `:warning: WARNING :warning:`;
-const second_line = `I can't publish a preview of this branch this because it would conflict with \`latest\` tag which is [reserved by NPM](https://docs.npmjs.com/cli/dist-tag#purpose).`;
+const second_line = `I can't publish a preview of this branch this because it would conflict with the \`latest\` tag which is [reserved by NPM](https://docs.npmjs.com/cli/dist-tag#purpose).`;
 
 markdown(`${first_line}\n\n${second_line}`)
 EOT

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -35,7 +35,7 @@ cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 
 const first_line = `:mega: Heads up!`;
-const second_line = `I didn't detect an NPM_AUTH_TOKEN which is necessary to publish a preview version of this package, and so I wasn't able to. However, this is perfectly normal for pull requests that are submitted from a forked repository.`;
+const second_line = `I didn't detect an NPM_AUTH_TOKEN which is necessary to publish a preview version of this package, and so I wasn't able to. However, this is perfectly normal for pull requests that are submitted from a forked repository, so no need to worry if that's what's going on here.`;
 
 markdown(`${first_line}\n\n${second_line}`)
 EOT

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -12,21 +12,7 @@ if [[ "$GITHUB_HEAD_REF" = "" ]]
     exit 1
 
 else
-  if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
-    then
-      echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
-      echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
-    
-cat << "EOT" > dangerfile.js
-const { markdown } = require('danger');
-
-const first_line = `ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.`;
-const second_line = `Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.`;
-
-markdown(`${first_line}\n\n${second_line}`)
-EOT
-
-  elif [[ "$GITHUB_HEAD_REF" = "latest" ]]
+  if [[ "$GITHUB_HEAD_REF" = "latest" ]]
     then
       echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
       echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
@@ -36,6 +22,20 @@ const { markdown } = require('danger');
 
 const first_line = `ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.`;
 const second_line = `Please change the name of your branch and resubmit the pull request.`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+
+  elif [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
+    then
+      echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
+      echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+    
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+
+const first_line = `ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.`;
+const second_line = `Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.`;
 
 markdown(`${first_line}\n\n${second_line}`)
 EOT


### PR DESCRIPTION
## Motivation
We had three scenarios where the action would exit with an error code:
  1. If this action isn't run from a pull request
  2. If the name of base branch is 'latest'
  3. If NPM_AUTH_TOKEN isn't accessible

Instead of returning an error code, we're suggesting the action still pass but provide instructions on why it didn't publish and what steps need to be taken to allow it to publish.

## Approach
### When not a pull request
The conditionals have been rearranged so that it will exit with an error code if the action is not run from a pull request because we can't make a pull request comment if it's not on a pull request.

### When base branch is 'latest'
Then the action checks if the base branch isn't named 'latest'. If it is, it won't publish and the action will post a comment on the PR explaining why we can't publish a preview of a branch called 'latest':
<img width="639" alt="Screen Shot 2019-10-22 at 3 32 06 PM" src="https://user-images.githubusercontent.com/29791650/67326274-4e023880-f4e4-11e9-8876-c87f6f63a023.png">

### When there is no access to NPM token
Then the action checks if NPM_AUTH_TOKEN is accessible. If it's not, the action won't publish and will post this comment:
<img width="637" alt="Screen Shot 2019-10-22 at 3 34 28 PM" src="https://user-images.githubusercontent.com/29791650/67326298-55294680-f4e4-11e9-87cd-9a6d89e4a33c.png">

### When all pass
And if all three conditions pass, then the action will proceed to publish and post its normal instructional comment.