### PR TITLE
Initial implementation of mono-publish

### DIFF
--- a/mono-publish-preview/Dockerfile
+++ b/mono-publish-preview/Dockerfile
@@ -1,4 +1,5 @@
-FROM frapsoft/zsh
+# FROM frapsoft/zsh
+FROM node:12-alpine
 
 RUN apk add --no-cache \
   git \
@@ -7,14 +8,15 @@ RUN apk add --no-cache \
   jq \ 
   zsh
 
-RUN sed -i -e "s/bin\/ash/bin\/zsh/" /etc/passwd
+# RUN sed -i -e "s/bin\/ash/bin\/zsh/" /etc/passwd
 
 COPY entrypoint.sh /entrypoint.sh
 
-RUN chmod +x /entrypoint.sh
+# RUN chmod +x /entrypoint.sh
 
-ENV SHELL /bin/zsh
+# ENV SHELL /bin/zsh
 
-ENTRYPOINT ["/entrypoint.sh"]
+# ENTRYPOINT ["/entrypoint.sh"]
 
 
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/mono-publish-preview/Dockerfile
+++ b/mono-publish-preview/Dockerfile
@@ -1,12 +1,7 @@
 # FROM frapsoft/zsh
 FROM node:12-alpine
 
-RUN apk add --no-cache \
-  git \
-  bash \ 
-  git-subtree \
-  jq \ 
-  zsh
+RUN apk add --no-cache git bash git-subtree jq
 
 # RUN sed -i -e "s/bin\/ash/bin\/zsh/" /etc/passwd
 

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -243,6 +243,8 @@ function runit(){
   # INPUT_IGNORE="minorepo/dos/sub/ minorepo/uno/sub2/ minorepo/dos"
   # GITHUB_HEAD_REF=nolatest
   # GITHUB_WORKSPACE=~/projects/georgia # ~/../workspace 
+  echo "before remote v"
+  git remote -v
 echo "before remote url set"
         git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
         git fetch origin # +refs/heads/*:refs/heads/*

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -26,6 +26,7 @@ function rundanger(){
 
 function publishgateway(){
   cd gateways/pro-portal
+  ls
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish --tag $tag

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -148,6 +148,9 @@ function filter(){
         # unset diffy[$i]
         echo $i: skipping "${diffy[$i]}" because of $ignoree
 #        fiffy+=(${diffy[$i]})
+      elif [ "${diffy[$i]}" = "." ]; then
+        echo $i: removing because we should not publish root on monorepo
+        unset diffy[$i]
       else
         echo $i: removing "${diffy[$i]}" because of $ignoree
         unset diffy[$i]

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -27,7 +27,7 @@ function rundanger(){
 function publishgateway(){
   cd $GITHUB_WORKSPACE/gateways/pro-portal
   ls
-  echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+  # echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish --tag $tag
   cd $GITHUB_WORKSPACE

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -43,7 +43,8 @@ EOT
 
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
         npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-        echo fake publish
+
+        echo -e "${BLUE}fake publishing of "`node -e \"console.log(require('./package.json').name)\"`"@"`node -e \"console.log(require('./package.json').version)\"`"${NC}"
         #npm publish --tag $tag
         
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -26,6 +26,7 @@ function rundanger(){
 
 function publishgateway(){
   cd gateways/pro-portal
+  echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish --tag $tag
   cd $GITHUB_WORKSPACE

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -6,16 +6,16 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-function doublechecky(){
-  echo test publishing
-  cd services/Consumer
-  echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-  npm publish
-  cd $GITHUB_WORKSPACE
-}
-# doublechecky
-# exit 1
+# function doublechecky(){
+#   echo test publishing
+#   cd services/Consumer
+#   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+#   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+#   npm publish
+#   cd $GITHUB_WORKSPACE
+# }
+# # doublechecky
+# # exit 1
 
 function rundanger(){
   echo running: danger

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -92,9 +92,10 @@ function filter(){
   echo running: filter
   diffy=(${piffy[@]})
   for ignoree in ${ignores[@]}; do
-    for diffydir in ${diffy[@]}; do
-      if [ -z "$(echo $diffydir | sed "s:^$ignoree.*::")" ]; then
-        unset diffy[${diffy[(ie)$diffydir]}]
+    for i in ${!diffy[@]}; do
+      if [ -z "$(echo ${diffydir[$i]} | sed "s:^$ignoree.*::")" ]; then
+        #unset diffy[${diffy[(ie)$diffydir]}]
+        unset diffy[$i]
       fi
     done
   done

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -8,7 +8,7 @@ NC='\033[0m'
 
 function doublechecky(){
   echo test publishing
-  cd services/Consumer
+#  cd services/Consumer
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -135,6 +135,7 @@ function findy(){
 
 function setup(){
   echo running: setup
+  echo yarn version $(yarn -v)
   yarn install
   tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
   echo '{"tag":"","packages":[]}' > published.json
@@ -191,15 +192,12 @@ function runit(){
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
         git config user.name "$GITHUB_ACTOR"
 
- diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
+  diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
   dird=$(diffytodir $diffs)
 
   # testing purposes
   echo dird arraychecker
-  arraychecker ${dird[@]}
-  for arg in ${dird[@]}; do
-    echo array: $arg
-  done;
+  arraychecker $dird
 
   PR="$(jq '."pull_request"' ../workflow/event.json)"
   jsonpath="../workflow/event.json"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -17,6 +17,12 @@ NC='\033[0m'
 # # doublechecky
 # # exit 1
 
+if [ "$INPUT_RUNNY" = "gateway" ]; then
+  echo gateways
+else
+  echo not gateways
+fi
+
 function rundanger(){
   echo running: danger
   yarn global add danger --dev
@@ -267,7 +273,7 @@ function arraychecker(){
   done;
 }
 
-runit
+#runit
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
   # dird=$(diffytodir $diffs)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -132,10 +132,9 @@ function findy(){
   }
 
   for i in ${!jiffy[@]}; do 
+    echo loop of jiffy with $i out of ${#jiffy[@]}
     pkgjsonfinder ${jiffy[$i]}
   done;
-
-  echo $piffy
 
   echo piffy array checker
   arraychecker $piffy
@@ -145,7 +144,6 @@ function findy(){
 
 function setup(){
   echo running: setup
-  echo yarn version $(yarn -v)
   yarn install
   tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
   echo '{"tag":"","packages":[]}' > published.json
@@ -195,7 +193,6 @@ function runit(){
 
         branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
         
-        # git checkout $branch
         git checkout $GITHUB_BASE_REF
         git checkout $GITHUB_HEAD_REF
         

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -249,16 +249,16 @@ function runit(){
   # GITHUB_HEAD_REF=nolatest
   # GITHUB_WORKSPACE=~/projects/georgia # ~/../workspace 
 
-        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
-        git fetch origin # +refs/heads/*:refs/heads/*
+        # git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
+        # git fetch origin # +refs/heads/*:refs/heads/*
 
-        branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
+        # branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
         
-        git checkout $GITHUB_BASE_REF
-        git checkout $GITHUB_HEAD_REF
+        # git checkout $GITHUB_BASE_REF
+        # git checkout $GITHUB_HEAD_REF
         
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-        git config user.name "$GITHUB_ACTOR"
+        # git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        # git config user.name "$GITHUB_ACTOR"
 
   diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
   dird=$(diffytodir $diffs)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -15,6 +15,7 @@ function doublechecky(){
   cd $GITHUB_WORKSPACE
 }
 doublechecky
+exit 1
 
 function rundanger(){
   echo running: danger

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -246,7 +246,7 @@ function runit(){
   echo "before remote v"
   git remote -v
 echo "before remote url set"
-        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
+#        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
         git fetch origin # +refs/heads/*:refs/heads/*
 
         branch="${GITHUB_HEAD_REF#*refs\/heads\/}"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -11,7 +11,6 @@ function doublechecky(){
 #  cd services/Consumer
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   #npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-  npm version patch
   npm publish
   cd $GITHUB_WORKSPACE
 }

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -255,7 +255,7 @@ function arraychecker(){
   done;
 }
 
-runit
+# runit
 
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -6,7 +6,14 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-cd
+function doublechecky(){
+  echo test publishing
+  cd minorepo/topublish/sub1
+  echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  cd $GITHUB_WORKSPACE
+}
+doublechecky
 
 function rundanger(){
   echo running: danger
@@ -236,8 +243,7 @@ markdown(`${first_line}\n\n${second_line}`)
 EOT
         rundanger
       else
-        #setup
-        echo setup
+        setup
       fi
     fi
   fi

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -25,7 +25,7 @@ function rundanger(){
 }
 
 function publishgateway(){
-  cd "gateways/pro-portal"
+  cd $GITHUB_WORKSPACE/gateways/pro-portal
   ls
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -41,13 +41,15 @@ EOT
         echo publish loop of $dir
         cd $dir
 
+        pkgname="`node -e \"console.log(require('./package.json').name)\"`"
+        pkgver="`node -e \"console.log(require('./package.json').version)\"`"
+        
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
         npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
 
-        echo -e "${BLUE}fake publishing of "`node -e \"console.log(require('./package.json').name)\"`"@"`node -e \"console.log(require('./package.json').version)\"`"${NC}"
+        echo -e "${BLUE}fake publishing of ${pkgname}@${pkgver}${NC}"
         #npm publish --tag $tag
         
-        pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         echo $(jq --arg PKG "$pkgname" '.packages[.packages | length] |= . + {"name": $PKG}' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json
 
         cd $GITHUB_WORKSPACE

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -108,17 +108,19 @@ function filter(){
       if [ -z "$(echo ${diffydir[$i]} | sed "s:^$ignoree.*::")" ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         unset diffy[$i]
+        echo $i: removing ${diffy[$i]}
       fi
     done
   done
   confirmedpkgs=($(echo ${diffy[@]} | xargs -n1 | sort -u | xargs))
 
   echo confirmedpkgs array checker
-  arraychecker $confirmedpkgs
+  arraychecker "${confirmedpkgs}"
   echo diffy array checker
-  arraychecker $diffy
+  arraychecker "${diffy[@]}"
 
-  publish
+#  publish
+exit 1
 }
 
 function findy(){
@@ -154,7 +156,7 @@ function findy(){
   arraychecker "${piffy[@]}"
   echo piffy length: ${#piffy[@]}
 
-# filter
+  filter
 }
 
 function setup(){
@@ -259,7 +261,6 @@ function arraychecker(){
 }
 
 runit
-
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
   # dird=$(diffytodir $diffs)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -25,7 +25,7 @@ function rundanger(){
 }
 
 function publishgateway(){
-  cd gateways/pro-portal
+  cd "gateways/pro-portal"
   ls
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -8,13 +8,11 @@ NC='\033[0m'
 
 function doublechecky(){
   echo test publishing
-  echo ls
-  ls
-  # cd services/consumer
-  # echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-  # npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-  # npm publish
-  # cd $GITHUB_WORKSPACE
+  cd services/Consumer
+  echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  npm publish
+  cd $GITHUB_WORKSPACE
 }
 doublechecky
 

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -27,6 +27,7 @@ markdown(`${first_line}\n\n${second_line}`)
 EOT
     else
       for dir in ${confirmedpkgs[@]}; do
+        echo publish loop of $dir
         cd $dir
 
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
@@ -101,6 +102,11 @@ function filter(){
   done
   confirmedpkgs=($(echo ${diffy[@]} | xargs -n1 | sort -u | xargs))
 
+  echo confirmedpkgs array checker
+  arraychecker $confirmedpkgs
+  echo diffy array checker
+  arraychecker $diffy
+
 publish
 }
 
@@ -130,6 +136,9 @@ function findy(){
   done;
 
   echo $piffy
+
+  echo piffy array checker
+  arraychecker $piffy
 
  filter
 }
@@ -196,9 +205,9 @@ function runit(){
   diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
   dird=$(diffytodir $diffs)
 
-  # testing purposes
-  echo dird arraychecker
-  arraychecker $dird
+  # testing purposes OKAY PASS
+  # echo dird arraychecker
+  # arraychecker $dird
 
   PR="$(jq '."pull_request"' ../workflow/event.json)"
   jsonpath="../workflow/event.json"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -188,10 +188,6 @@ function findy(){
     pkgjsonfinder ${jiffy[$i]}
   done;
 
-  # echo piffy array checker
-  # arraychecker "${piffy[@]}"
-  # echo piffy length: ${#piffy[@]}
-
   filter
 }
 
@@ -260,12 +256,8 @@ function runit(){
         # git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
         # git config user.name "$GITHUB_ACTOR"
 
-  diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
-  dird=$(diffytodir $diffs)
-
-  # testing purposes OKAY PASS
-  # echo dird arraychecker
-  # arraychecker $dird
+        # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
+        # dird=$(diffytodir $diffs)
 
   PR="$(jq '."pull_request"' ../workflow/event.json)"
   jsonpath="../workflow/event.json"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -106,7 +106,7 @@ function filter(){
   fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
-      if [ "$(echo ${diffydir[$i]} | sed -E "s:^$ignoree.*::")" ]; then
+      if [ "$(echo "${diffydir[$i]}" | sed -E "s:^$ignoree.*::")" ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         # unset diffy[$i]
         echo $i: skipping "${diffy[$i]}" because of $ignoree

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -48,7 +48,7 @@ EOT
         npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
 
         echo -e "${BLUE}fake publishing of ${pkgname}@${pkgver}${NC}"
-        #npm publish --tag $tag
+        npm publish --tag $tag
         
         echo $(jq --arg PKG "$pkgname" '.packages[.packages | length] |= . + {"name": $PKG}' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json
 

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -50,6 +50,8 @@ const last_line = `Once the branch associated with this tag is deleted (usually 
 
 markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
 EOT
+
+rundanger
 }
 
 function publish(){

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env zsh
+#!/usr/bin/env bash
 set -e
 
 RED='\033[1;31m'

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -103,20 +103,29 @@ EOT
 function filter(){
   echo running: filter
   diffy=(${piffy[@]})
+  fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
       if [ -z "$(echo ${diffydir[$i]} | sed "s:^$ignoree.*::")" ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
-        unset diffy[$i]
-        echo $i: removing ${diffy[$i]}
+        # unset diffy[$i]
+        echo $i: skipping "${diffy[$i]}" because of $ignoree
+      else
+        echo $i: adding "${diffy[$i]}" because of $ignoree
+        fiffy+=(${diffy[$i]})
       fi
     done
   done
-  confirmedpkgs=($(echo ${diffy[@]} | xargs -n1 | sort -u | xargs))
+  confirmedpkgs=($(echo ${fiffy[@]} | xargs -n1 | sort -u | xargs))
 
+  echo fiffy array checker
+  echo fiffy length: ${#fiffy[@]}
+  arraychecker "${fiffy[@]}"
   echo confirmedpkgs array checker
-  arraychecker "${confirmedpkgs}"
+  echo confirmedpkgs length: ${#confirmedpkgs[@]}
+  arraychecker "${confirmedpkgs[@]}"
   echo diffy array checker
+  echo diffy length: ${#diffy[@]}
   arraychecker "${diffy[@]}"
 
 #  publish
@@ -152,9 +161,9 @@ function findy(){
     pkgjsonfinder ${jiffy[$i]}
   done;
 
-  echo piffy array checker
-  arraychecker "${piffy[@]}"
-  echo piffy length: ${#piffy[@]}
+  # echo piffy array checker
+  # arraychecker "${piffy[@]}"
+  # echo piffy length: ${#piffy[@]}
 
   filter
 }

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -103,20 +103,21 @@ EOT
 function filter(){
   echo running: filter
   diffy=(${piffy[@]})
-  fiffy=()
+  #fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
       if [ $(echo "${diffy[$i]}" | sed -E "s:^$ignoree.*::") ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         # unset diffy[$i]
-        echo $i: adding "${diffy[$i]}" because of $ignoree
-        fiffy+=(${diffy[$i]})
-      else
         echo $i: skipping "${diffy[$i]}" because of $ignoree
+#        fiffy+=(${diffy[$i]})
+      else
+        echo $i: removing "${diffy[$i]}" because of $ignoree
+        unset diffy[$i]
       fi
     done
   done
-  confirmedpkgs=($(echo "${fiffy[@]}" | xargs -n1 | sort -u | xargs))
+  confirmedpkgs=($(echo "${diffy[@]}" | xargs -n1 | sort -u | xargs))
 
   echo confirmedpkgs array checker
   echo confirmedpkgs length: ${#confirmedpkgs[@]}

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -8,7 +8,7 @@ NC='\033[0m'
 
 function doublechecky(){
   echo test publishing
-  cd minorepo/topublish/sub1
+  cd services/consumer
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish
@@ -256,7 +256,7 @@ function arraychecker(){
   done;
 }
 
-runit
+#runit
 
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -247,7 +247,7 @@ function runit(){
   git remote -v
 echo "before remote url set"
 #        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
-        git fetch origin # +refs/heads/*:refs/heads/*
+        # git fetch origin # +refs/heads/*:refs/heads/*
 
         branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
 echo "before checkout"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -212,6 +212,8 @@ function setup(){
 
 function runit(){
   echo running: runit
+  echo repo: $GITHUB_REPOSITORY
+  echo actor: $GITHUB_ACTOR
   function unslash(){
     for unslash in $*; do
       echo $unslash | sed 's:\/$::g';

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -69,10 +69,7 @@ EOT
     else
       for dir in ${confirmedpkgs[@]}; do
         echo publish loop of $dir
-        cd $GITHUB_WORKSPACE/$dir
-        echo before ls
-        ls
-        echo afterr ls
+        cd $dir
 
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         pkgver="`node -e \"console.log(require('./package.json').version)\"`"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -143,17 +143,19 @@ function filter(){
   #fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
-      if [ $(echo "${diffy[$i]}" | sed -E "s:^$ignoree.*::") ]; then
-        #unset diffy[${diffy[(ie)$diffydir]}]
-        # unset diffy[$i]
-        echo $i: skipping "${diffy[$i]}" because of $ignoree
-#        fiffy+=(${diffy[$i]})
-      elif [[ "${diffy[$i]}" = "." ]]; then
-        echo $i: removing because we should not publish root on monorepo
+      if [ "${diffy[$i]}" = "." ]; then
+        echo $i: removing "${diffy[$i]}" because monorepo should not publish root
         unset diffy[$i]
       else
-        echo $i: removing "${diffy[$i]}" because of $ignoree
-        unset diffy[$i]
+        if [ $(echo "${diffy[$i]}" | sed -E "s:^$ignoree.*::") ]; then
+          #unset diffy[${diffy[(ie)$diffydir]}]
+          # unset diffy[$i]
+          echo $i: skipping "${diffy[$i]}" because of $ignoree
+  #        fiffy+=(${diffy[$i]})
+        else
+          echo $i: removing "${diffy[$i]}" because of $ignoree
+          unset diffy[$i]
+        fi
       fi
     done
   done

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -69,7 +69,7 @@ EOT
     else
       for dir in ${confirmedpkgs[@]}; do
         echo publish loop of $dir
-        cd $dir
+        cd $GITHUB_WORKSPACE/$dir
 
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         pkgver="`node -e \"console.log(require('./package.json').version)\"`"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -8,11 +8,13 @@ NC='\033[0m'
 
 function doublechecky(){
   echo test publishing
-  cd services/consumer
-  echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-  npm publish
-  cd $GITHUB_WORKSPACE
+  echo ls
+  ls
+  # cd services/consumer
+  # echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+  # npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  # npm publish
+  # cd $GITHUB_WORKSPACE
 }
 doublechecky
 

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -6,6 +6,8 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+cd
+
 function rundanger(){
   echo running: danger
   yarn global add danger --dev
@@ -116,23 +118,26 @@ function findy(){
   piffy=()
 
   function pkgjsonfinder(){
+    echo -e "${GREEN}pkgjsonfinder with $1"
     cd $GITHUB_WORKSPACE
     cd $1
     if [ ! -f "package.json" ]; then
       if [ "$(echo $1 | grep -c "/")" = "1" ]; then
         sub=$(echo $1 | sed 's:\(.*\)\/.*:\1:g');
+        echo -e "${RED}no pkgjson for $1 so looping with $sub"
         pkgjsonfinder $sub
       else
+        echo -e "${RED}no pkgjson and last dir so ."
         piffy+=(".")
       fi
     else
+      echo -e "${GREEN}pkgjson found so adding $1 to piffy"
       piffy+=("$1")
     fi
     cd $GITHUB_WORKSPACE
   }
 
   for i in ${!jiffy[@]}; do 
-    echo loop of jiffy with $i out of ${#jiffy[@]}
     pkgjsonfinder ${jiffy[$i]}
   done;
 

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -106,7 +106,7 @@ function filter(){
   fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
-      if [ -z "$(echo ${diffydir[$i]} | sed -E "s:^$ignoree.*::")" ]; then
+      if [ "$(echo ${diffydir[$i]} | sed -E "s:^$ignoree.*::")" ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         # unset diffy[$i]
         echo $i: skipping "${diffy[$i]}" because of $ignoree

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -109,15 +109,15 @@ function filter(){
       if [ $(echo "${diffy[$i]}" | sed -E "s:^$ignoree.*::") ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         # unset diffy[$i]
-        echo $i: skipping "${diffy[$i]}" because of $ignoree
-      else
         echo $i: adding "${diffy[$i]}" because of $ignoree
         fiffy+=(${diffy[$i]})
+      else
+        echo $i: skipping "${diffy[$i]}" because of $ignoree
       fi
     done
   done
   confirmedpkgs=($(echo ${fiffy[@]} | xargs -n1 | sort -u | xargs))
-  
+
   echo fiffy array checker
   echo fiffy length: ${#fiffy[@]}
   arraychecker "${fiffy[@]}"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -116,17 +116,11 @@ function filter(){
       fi
     done
   done
-  confirmedpkgs=($(echo ${fiffy[@]} | xargs -n1 | sort -u | xargs))
+  confirmedpkgs=($(echo "${fiffy[@]}" | xargs -n1 | sort -u | xargs))
 
-  echo fiffy array checker
-  echo fiffy length: ${#fiffy[@]}
-  arraychecker "${fiffy[@]}"
   echo confirmedpkgs array checker
   echo confirmedpkgs length: ${#confirmedpkgs[@]}
   arraychecker "${confirmedpkgs[@]}"
-  echo diffy array checker
-  echo diffy length: ${#diffy[@]}
-  arraychecker "${diffy[@]}"
 
 #  publish
 exit 1

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -152,7 +152,7 @@ function findy(){
   echo piffy array checker
   arraychecker $piffy
 
- filter
+# filter
 }
 
 function setup(){
@@ -256,7 +256,7 @@ function arraychecker(){
   done;
 }
 
-# runit
+runit
 
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -34,7 +34,7 @@ function publishgateway(){
 
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
-const pjson = require('./package.json');
+const pjson = require('./gateways/pro-portal/package.json');
 
 const current = `https://www.npmjs.com/package/${pjson.name}/v/${pjson.version}`
 const branch = process.env.GITHUB_HEAD_REF;
@@ -42,14 +42,13 @@ const masked = branch.replace(/\//g, '_');
 
 const install_version = `npm install ${pjson.name}@${pjson.version}`;
 
-const first_line = `A preview package of this pull request has been released to NPM with the tag \`${masked}\`.`;
+const first_line = `A preview package of this pull request has been released to GPR with the tag \`${masked}\`.`;
 const second_line = `You can try it out by running the following command:`;
 const install_tag = `$ npm install ${pjson.name}@${masked}`;
 const fourth_line = `or by updating your package.json to:`
 const update_json = `\{\n  \"${pjson.name}\": \"${masked}\"\n\}`
-const last_line = `Once the branch associated with this tag is deleted (usually once the PR is merged or closed), it will no longer be available. However, it currently references [${pjson.name}@${pjson.version}](${current}) which will be available to install forever.`;
 
-markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
+markdown(`${first_line}\n\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\``)
 EOT
 
 rundanger

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -17,11 +17,12 @@ NC='\033[0m'
 # # doublechecky
 # # exit 1
 
-if [ "$INPUT_RUNNY" = "gateway" ]; then
+if [ "$INPUT_RUNNY" != "gateway" ]; then
   echo gateways
 else
   echo not gateways
 fi
+exit 1
 
 function rundanger(){
   echo running: danger

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -43,7 +43,8 @@ EOT
 
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
         npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-        npm publish --tag $tag
+        echo fake publish
+        #npm publish --tag $tag
         
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         echo $(jq --arg PKG "$pkgname" '.packages[.packages | length] |= . + {"name": $PKG}' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json
@@ -123,8 +124,7 @@ function filter(){
   echo confirmedpkgs length: ${#confirmedpkgs[@]}
   arraychecker "${confirmedpkgs[@]}"
 
-#  publish
-exit 1
+publish
 }
 
 function findy(){

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -257,7 +257,7 @@ function arraychecker(){
   done;
 }
 
-#runit
+runit
 
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -302,7 +302,7 @@ function arraychecker(){
   done;
 }
 
-#runit
+runit
 
   # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
   # dird=$(diffytodir $diffs)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -109,7 +109,7 @@ function filter(){
   echo diffy array checker
   arraychecker $diffy
 
-publish
+  publish
 }
 
 function findy(){
@@ -236,7 +236,8 @@ markdown(`${first_line}\n\n${second_line}`)
 EOT
         rundanger
       else
-        setup
+        #setup
+        echo setup
       fi
     fi
   fi

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -151,7 +151,8 @@ function findy(){
   done;
 
   echo piffy array checker
-  arraychecker $piffy
+  arraychecker "${piffy[@]}"
+  echo piffy length: ${#piffy[@]}
 
 # filter
 }

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -14,8 +14,8 @@ function doublechecky(){
   npm publish
   cd $GITHUB_WORKSPACE
 }
-doublechecky
-exit 1
+# doublechecky
+# exit 1
 
 function rundanger(){
   echo running: danger

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -8,9 +8,9 @@ NC='\033[0m'
 
 function doublechecky(){
   echo test publishing
-#  cd services/Consumer
+  cd services/Consumer
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-  #npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish
   cd $GITHUB_WORKSPACE
 }

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -106,7 +106,7 @@ function filter(){
   fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
-      if [ "$(echo "${diffydir[$i]}" | sed -E "s:^$ignoree.*::")" ]; then
+      if [ $(echo "${diffy[$i]}" | sed -E "s:^$ignoree.*::") ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         # unset diffy[$i]
         echo $i: skipping "${diffy[$i]}" because of $ignoree
@@ -117,7 +117,7 @@ function filter(){
     done
   done
   confirmedpkgs=($(echo ${fiffy[@]} | xargs -n1 | sort -u | xargs))
-
+  
   echo fiffy array checker
   echo fiffy length: ${#fiffy[@]}
   arraychecker "${fiffy[@]}"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -69,7 +69,10 @@ EOT
     else
       for dir in ${confirmedpkgs[@]}; do
         echo publish loop of $dir
-        cd $GITHUB_WORKSPACE/$dir
+        cd $GITHUB_WORKSPACE/"$dir"
+        echo before ls
+        ls
+        echo afterr ls
 
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         pkgver="`node -e \"console.log(require('./package.json').version)\"`"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -10,7 +10,8 @@ function doublechecky(){
   echo test publishing
 #  cd services/Consumer
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-  npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  #npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  npm version patch
   npm publish
   cd $GITHUB_WORKSPACE
 }

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -148,7 +148,7 @@ function filter(){
         # unset diffy[$i]
         echo $i: skipping "${diffy[$i]}" because of $ignoree
 #        fiffy+=(${diffy[$i]})
-      elif [ "${diffy[$i]}" = "." ]; then
+      elif [[ "${diffy[$i]}" = "." ]]; then
         echo $i: removing because we should not publish root on monorepo
         unset diffy[$i]
       else

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -106,7 +106,7 @@ function filter(){
   fiffy=()
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
-      if [ -z "$(echo ${diffydir[$i]} | sed "s:^$ignoree.*::")" ]; then
+      if [ -z "$(echo ${diffydir[$i]} | sed -E "s:^$ignoree.*::")" ]; then
         #unset diffy[${diffy[(ie)$diffydir]}]
         # unset diffy[$i]
         echo $i: skipping "${diffy[$i]}" because of $ignoree

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -243,14 +243,16 @@ function runit(){
   # INPUT_IGNORE="minorepo/dos/sub/ minorepo/uno/sub2/ minorepo/dos"
   # GITHUB_HEAD_REF=nolatest
   # GITHUB_WORKSPACE=~/projects/georgia # ~/../workspace 
-
+echo "before remote url set"
         git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
         git fetch origin # +refs/heads/*:refs/heads/*
 
         branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
+echo "before checkout"
         
         git checkout $GITHUB_BASE_REF
         git checkout $GITHUB_HEAD_REF
+echo "before config"
         
         git config user.email "resideo@users.noreply.github.com"
         git config user.name "resideo"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -69,7 +69,7 @@ EOT
     else
       for dir in ${confirmedpkgs[@]}; do
         echo publish loop of $dir
-        cd $GITHUB_WORKSPACE/"$dir"
+        cd $GITHUB_WORKSPACE/$dir
         echo before ls
         ls
         echo afterr ls

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -246,19 +246,19 @@ function runit(){
   # GITHUB_HEAD_REF=nolatest
   # GITHUB_WORKSPACE=~/projects/georgia # ~/../workspace 
 
-        # git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
-        # git fetch origin # +refs/heads/*:refs/heads/*
+        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
+        git fetch origin # +refs/heads/*:refs/heads/*
 
-        # branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
+        branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
         
-        # git checkout $GITHUB_BASE_REF
-        # git checkout $GITHUB_HEAD_REF
+        git checkout $GITHUB_BASE_REF
+        git checkout $GITHUB_HEAD_REF
         
-        # git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-        # git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        git config user.name "$GITHUB_ACTOR"
 
-        # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
-        # dird=$(diffytodir $diffs)
+        diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
+        dird=$(diffytodir $diffs)
 
   PR="$(jq '."pull_request"' ../workflow/event.json)"
   jsonpath="../workflow/event.json"

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -209,8 +209,6 @@ function setup(){
 
 function runit(){
   echo running: runit
-  echo repo: $GITHUB_REPOSITORY
-  echo actor: $GITHUB_ACTOR
   function unslash(){
     for unslash in $*; do
       echo $unslash | sed 's:\/$::g';
@@ -254,8 +252,8 @@ function runit(){
         git checkout $GITHUB_BASE_REF
         git checkout $GITHUB_HEAD_REF
         
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-        git config user.name "$GITHUB_ACTOR"
+        git config user.email "resideo@users.noreply.github.com"
+        git config user.name "resideo"
 
         diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
         dird=$(diffytodir $diffs)

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -132,7 +132,6 @@ EOT
 
   rundanger
   echo -e "${GREEBN}SUCCESS${NC}"
-  exit 1
 }
 
 function filter(){

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -11,6 +11,7 @@ function doublechecky(){
   cd minorepo/topublish/sub1
   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+  npm publish
   cd $GITHUB_WORKSPACE
 }
 doublechecky

--- a/mono-publish-preview/entrypoint.sh
+++ b/mono-publish-preview/entrypoint.sh
@@ -6,17 +6,6 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-# function doublechecky(){
-#   echo test publishing
-#   cd services/Consumer
-#   echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-#   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-#   npm publish
-#   cd $GITHUB_WORKSPACE
-# }
-# # doublechecky
-# # exit 1
-
 function rundanger(){
   echo running: danger
   yarn global add danger --dev
@@ -26,8 +15,6 @@ function rundanger(){
 
 function publishgateway(){
   cd $GITHUB_WORKSPACE/gateways/pro-portal
-  ls
-  # echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
   npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
   npm publish --tag $tag
   cd $GITHUB_WORKSPACE
@@ -68,14 +55,10 @@ markdown(`${first_line}\n\n${second_line}`)
 EOT
     else
       for dir in ${confirmedpkgs[@]}; do
-        echo publish loop of $dir
         cd $dir
 
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         pkgver="`node -e \"console.log(require('./package.json').version)\"`"
-        
-        # jordan says he will do
-        #echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
 
         npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
 
@@ -123,7 +106,7 @@ function package(name){
   </details>`
 }
 
-const first_line = `The packages of this pull request has been released to Github Package Registry.`;
+const first_line = `The packages of this pull request have been released to Github Package Registry.`;
 const second_line = `Click on the following packages for instructions on how to install them:`;
 
 markdown(`${first_line}\n${second_line}\n${packages()}`)
@@ -141,16 +124,11 @@ function filter(){
   for ignoree in ${ignores[@]}; do
     for i in ${!diffy[@]}; do
       if [ "${diffy[$i]}" = "." ]; then
-        echo $i: removing "${diffy[$i]}" because monorepo should not publish root
         unset diffy[$i]
       else
         if [ $(echo "${diffy[$i]}" | sed -E "s:^$ignoree.*::") ]; then
-          #unset diffy[${diffy[(ie)$diffydir]}]
-          # unset diffy[$i]
           echo $i: skipping "${diffy[$i]}" because of $ignoree
-  #        fiffy+=(${diffy[$i]})
         else
-          echo $i: removing "${diffy[$i]}" because of $ignoree
           unset diffy[$i]
         fi
       fi
@@ -158,11 +136,7 @@ function filter(){
   done
   confirmedpkgs=($(echo "${diffy[@]}" | xargs -n1 | sort -u | xargs))
 
-  echo confirmedpkgs array checker
-  echo confirmedpkgs length: ${#confirmedpkgs[@]}
-  arraychecker "${confirmedpkgs[@]}"
-
-publish
+  publish
 }
 
 function findy(){
@@ -233,39 +207,22 @@ function runit(){
   defaults=("node_modules" ".github")
   ignores=($(unslash $INPUT_IGNORE) ${defaults[@]})
 
-  # echo array checking ignores arg ver 1 brackets inside brakcet
-  # arraychecker (${ignores[@]})
-  # echo end of checking array
-  # echo array checking ignores arg ver 2 brackets
-  # arraychecker ${ignores[@]}
-  # echo end of checking array
-  # echo array checking ignores arg ver 2 just var
-  # arraychecker $ignores
-  # echo end of checking array
-
-  # placeholder variables for testing offline
+  # variables for testing offline
   # diffs=$(git diff --name-only 2e5c6c9..91dd994)
   # INPUT_IGNORE="minorepo/dos/sub/ minorepo/uno/sub2/ minorepo/dos"
   # GITHUB_HEAD_REF=nolatest
   # GITHUB_WORKSPACE=~/projects/georgia # ~/../workspace 
-  echo "before remote v"
-  git remote -v
-echo "before remote url set"
-#        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
-        # git fetch origin # +refs/heads/*:refs/heads/*
 
-        branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
-echo "before checkout"
-        
-        git checkout $GITHUB_BASE_REF
-        git checkout $GITHUB_HEAD_REF
-echo "before config"
-        
-        git config user.email "resideo@users.noreply.github.com"
-        git config user.name "resideo"
+  branch="${GITHUB_HEAD_REF#*refs\/heads\/}"
+  
+  git checkout $GITHUB_BASE_REF
+  git checkout $GITHUB_HEAD_REF
+  
+  git config user.email "resideo@users.noreply.github.com"
+  git config user.name "resideo"
 
-        diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
-        dird=$(diffytodir $diffs)
+  diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
+  dird=$(diffytodir $diffs)
 
   PR="$(jq '."pull_request"' ../workflow/event.json)"
   jsonpath="../workflow/event.json"
@@ -298,17 +255,4 @@ EOT
   fi
 }
 
-function arraychecker(){
-  for arg in $*; do
-    echo -e "${RED}array: ${YELLOW}$arg${NC}"
-  done;
-}
-
 runit
-
-  # diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
-  # dird=$(diffytodir $diffs)
-  # echo dird arraychecker
-  # for arg in $diffs; do
-  #   echo array: $arg
-  # done;

--- a/zeus-publish-preview/Dockerfile
+++ b/zeus-publish-preview/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache git bash git-subtree jq
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/zeus-publish-preview/README.md
+++ b/zeus-publish-preview/README.md
@@ -1,0 +1,28 @@
+# Publish PR Preview
+This action will:
+- Check for accessibility to NPM token in secrets.
+- Make sure this action is being run from a pull request.
+- Make sure the name of the head branch of the pull request isn't `latest` to avoid conflicts with NPM tagging.
+- Update package version with snapshot, publish to NPM with branch name as tag.
+- Comment on pull request with instructions on how to access the package.
+
+## Requirements
+- Pass in `GITHUB_TOKEN` and `NPM_AUTH_TOKEN`.
+- Optional: `NPM_PUBLISH` argument is available if you want to run a different command. `npm publish` will run as default.
+
+## Usage
+```yaml
+jobs:
+  job_name:
+    name: Job Name
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish PR Preview
+      uses: thefrontside/actions/publish-pr-preview@master
+      with:
+        NPM_PUBLISH: npm run my-script
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+```

--- a/zeus-publish-preview/entrypoint.sh
+++ b/zeus-publish-preview/entrypoint.sh
@@ -6,7 +6,6 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-
 PR="$(jq '."pull_request"' ../workflow/event.json)"
 if [[ "$PR" = "null" ]]
   then

--- a/zeus-publish-preview/entrypoint.sh
+++ b/zeus-publish-preview/entrypoint.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+set -e
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+
+PR="$(jq '."pull_request"' ../workflow/event.json)"
+if [[ "$PR" = "null" ]]
+  then
+    echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
+    exit 1
+
+else
+  if [[ "$GITHUB_HEAD_REF" = "latest" ]]
+    then
+      echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
+      echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
+
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+
+const first_line = `:warning: WARNING :warning:`;
+const second_line = `I can't publish a preview of this branch this because it would conflict with the \`latest\` tag which is [reserved by NPM](https://docs.npmjs.com/cli/dist-tag#purpose).`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+
+  else
+    yarn
+    npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
+    echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+    tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
+    if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]
+      then
+        npm publish --access=public --tag $tag
+      else
+        $INPUT_NPM_PUBLISH --access=public --tag $tag
+    fi
+
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+const pjson = require('./package.json');
+
+const current = `https://www.npmjs.com/package/${pjson.name}/v/${pjson.version}`
+const branch = process.env.GITHUB_HEAD_REF;
+const masked = branch.replace(/\//g, '_');
+
+const install_version = `npm install ${pjson.name}@${pjson.version}`;
+
+const first_line = `A preview package of this pull request has been released to NPM with the tag \`${masked}\`.`;
+const second_line = `You can try it out by running the following command:`;
+const install_tag = `$ npm install ${pjson.name}@${masked}`;
+const fourth_line = `or by updating your package.json to:`
+const update_json = `\{\n  \"${pjson.name}\": \"${masked}\"\n\}`
+const last_line = `Once the branch associated with this tag is deleted (usually once the PR is merged or closed), it will no longer be available. However, it currently references [${pjson.name}@${pjson.version}](${current}) which will be available to install forever.`;
+
+markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
+EOT
+
+  fi
+
+jsonpath="../workflow/event.json"
+headurl="$(jq '."pull_request"|."head"|."repo"|."url"' $jsonpath)"
+baseurl="$(jq '."pull_request"|."base"|."repo"|."url"' $jsonpath)"
+
+  if [[ "$headurl" = "$baseurl" ]]; 
+  then
+    yarn global add danger --dev
+    export PATH="$(yarn global bin):$PATH"
+    danger ci
+  else
+    echo -e "${RED}Not generating a comment because this pull request was created from a forked repository.${NC}"
+    echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+  fi
+
+fi


### PR DESCRIPTION
### Motivation
This pull request is to take the first steps in implementing monorepo support for Transparent NPM Publishing. This action was created around the needs of Zeus but there are still many decisions to be made to find the right balance between customizability and simplicity..

### Approach
For the sake of time management I didn't make a colourful diagram but the example below should display the workflow of this action:
```js
run runit()

runit(){
  if (!pull_request || head_url != base_url || branch_name = "latest") {
    console.log(warning)
    if(pull_request){
      generate_comment(warning)
    }
  } else {
    setup()
  }
}

setup(){
  yarn
  touch published.json
  findy()
}

findy(){
  loop of directories of files changed {
    find_package_json(){
      cd into directory
      if(package.json){
        findy_result.add(directory)
      } else {
        if(subfolders){
          go up one folder and find_package_json()
        } else {
          findy_result.add(root_folder)
        }
      }
    }
  }
  filter(findy_result)
}

filter(){
  let filter_result = [findy_result];
  loop of ignore argument from workflow and default ignore directories {
    loop of findy_result {
      if (beginning of findy_result[@] matches ignore_argument[@]){
        filter_result.remove(findy_result[@])
      }
    }
  }
  filter_result.remove_duplicates()
  publish(filter_result)
}

publish(){
  if (filter_result.length = 0){
    generate_comment(message to say nothing was published)
  } else {
    loop of filter_result {
      cd into package directory in filter_result
      authenticate for github package registry
      update package version with commit SHA snapshot // i.e. 1.0.0-af02j30
      publish --tag branch_name
      append published package information to published.json from setup()
      cd root for next iteration of loop
    }
    generate_comment(instructions on how to access each of the published packages)
  }
}
```

This is an example of the auto-generated comment once the packages are published successfully without any errors:
![Screen Shot 2019-10-24 at 5 28 32 PM](https://user-images.githubusercontent.com/29791650/67598774-68365380-f73c-11e9-926a-11943d0feb41.png)

### TODOs
- [ ] Possibly choose a better name than `mono-publish-preview`?
- [x] For Zeus: make sure to rebase so that it can use `yarn install` instead of `yarn install-with-bin-links`.
- [x] ~~Create another argument to give users the ability to choose between `NPMJS` and `GPR`?~~ Not yet.
- [x] ~~Should the `mono-release-publish` logic be in the same action as `mono-release-preview`? See `Development` section below.~~ Nah.
- [ ] `npm dist-tag rm $tag` does not work for GPR; this would mean the tags remain indefinitely which could be a good thing?
- [x] ~~Use `jq` to be more explicit with the conditionals.~~ Done and more. See comment below.
- [ ] Rearrange functions for tidier code
  - setup() first and then runit() maybe but for the sake of getting this action up and running we'll do that later

<!-- ### Development
Our workflows can be split into two categories: 
1. publishing preview for pull requests
2. publishing release for commits (which we assume are merges because you don't push directly to master or release-*)

For reasons specified in [PR #29](https://github.com/thefrontside/actions/pull/29), we have one action per workflow to handle all our needs.

We could combine the two actions into one but here's why we haven't:
<img width="951" alt="Screen Shot 2019-10-25 at 11 10 17 AM" src="https://user-images.githubusercontent.com/29791650/67598027-8a2ed680-f73a-11e9-828b-6250ab94ca6b.png">
The two actions do not overlap much in functionality and we'd be combining them only for the benefit of the two workflows to call one action which really doesn't provide any advantages.

However, for the case of the `mono-publish` action, do we want one monorepo-action to handle both publish-release and publish-preview?

The logic for monorepo action may overlap for `publish-preview` and `publish-release` which would warrant combining the two actions into one.
<img width="914" alt="Screen Shot 2019-10-25 at 11 13 15 AM" src="https://user-images.githubusercontent.com/29791650/67598041-92871180-f73a-11e9-9af2-6e127f5591a0.png">
We won't know for sure until we figure out what needs to be done for our monorepo `publish-release` workflow but I thought I'd get the conversation started because the proposed action currently already has some conditionals (e.g. checking if the workflow is being run from a pull request to determine whether to run Danger CI) in preparation for the merge.

If we already know we would want to separate the two workflows into its own action, I can go ahead and clean up this action to be `publish-preview` specific. -->

### Tests
test from minkimcello/zeus-api here (WIP)
