### PR TITLE
Incorporate data from event.json into conditionals for publish-pr-preview

### DIFF
--- a/publish-pr-preview/Dockerfile
+++ b/publish-pr-preview/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --no-cache git bash git-subtree
+RUN apk add --no-cache git bash git-subtree jq
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -74,8 +74,12 @@ EOT
 
   fi
 
-  fork="$(jq '."repository"|."fork"' ../workflow/event.json)"
-  if [[ "$fork" = "false" ]]; then
+  head="$(jq '."head"|."repo"|."fork"' ../workflow/event.json)"
+  headowner="$(jq '."head"|."repo"|."owner"|."login"' ../workflow/event.json)"
+  base="$(jq '."base"|."repo"|."fork"' ../workflow/event.json)"
+  baseowner="$(jq '."base"|."repo"|."owner"|."login"' ../workflow/event.json)"
+
+  if [[ "$head" = "false" && "$base" = "false" ]] || [[ "$head" = "true" && "$base" = "true" && "$headowner" -eq "$baseowner" ]]; then
     yarn global add danger --dev
     export PATH="$(yarn global bin):$PATH"
     danger ci

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -29,7 +29,6 @@ EOT
   elif [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
     then
       echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
-      echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
     
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
@@ -75,8 +74,14 @@ EOT
 
   fi
 
-  yarn global add danger --dev
-  export PATH="$(yarn global bin):$PATH"
-  danger ci
+  fork="$(jq '."repository"|."fork"' ../workflow/event.json)"
+  if [[ "$fork" = "false" ]]; then
+    yarn global add danger --dev
+    export PATH="$(yarn global bin):$PATH"
+    danger ci
+  else
+    echo -e "${RED}Not generating a comment because this is a forked repository.${NC}"
+    echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+  fi
 
 fi

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -77,20 +77,16 @@ EOT
   fi
 
 jsonpath="../workflow/event.json"
-headfork="$(jq '."pull_request"|."head"|."repo"|."fork"' $jsonpath)"
-basefork="$(jq '."pull_request"|."base"|."repo"|."fork"' $jsonpath)"
 headurl="$(jq '."pull_request"|."head"|."repo"|."url"' $jsonpath)"
 baseurl="$(jq '."pull_request"|."base"|."repo"|."url"' $jsonpath)"
 
-  if 
-    [[ "$headfork" = "false" && "$basefork" = "false" ]] || 
-    [[ "$headfork" = "true" && "$basefork" = "true" && "$headurl" = "$baseurl" ]]; 
+  if [[ "$headurl" = "$baseurl" ]]; 
   then
     yarn global add danger --dev
     export PATH="$(yarn global bin):$PATH"
     danger ci
   else
-    echo -e "${RED}Not generating a comment because this is a forked repository.${NC}"
+    echo -e "${RED}Not generating a comment because this pull request was created from a forked repository.${NC}"
     echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
   fi
 


### PR DESCRIPTION
### Motivation
Since our actions are currently written in shell I've had difficulty writing conditionals that depended on whether or not the workflow is being run from a forked repository. Up until now I kept using workarounds to avoid finding a solution to that issue, but now we need a way to prevent Danger CI from triggering if on a fork since it won't have write-access from its `GITHUB_TOKEN`.

### Approach
Don't know why this never occurred to me but I decided to finally have a look inside the `event.json` file and it has everything we need! I've added `jq` to the dockerfile which allows us to retrieve values from a json file in shell script. 

Danger CI will only run on one condition: when `base.repo.url` and `head.repo.url` are equal. This conditional allows us to not have to unnecessarily discriminate against forked repositories. A PR made *to* and *from* its original repository will have matching repo url from both its base and head ref. We're only trying to prevent this from running if a forked repository is making a pull request to the original repository. If a forked repository makes a PR against itself then it should be allowed to run assuming they changed the package name and added the necessary tokens in their secrets.

I've also added a conditional for when the `event.json` does not have data under `pull_request` so that the `publish-pr-preview` action can exit on an error since it's only meant to run from a PR. Previously, we achieved this by checking for `GITHUB_HEAD_REF` which worked fine but wasn't the most "accurate" approach.

Lastly, the difference in build time for when `jq` is included is negligible so I was wondering where else we can take advantage of this new development. `synchronize-npm-tags` and `synchronize-with-npm` both run on the original repository so at the moment I can't see any upgrade opportunities from utilizing data from the `event.json`. However, the `mono-publish` action can probably benefit from this which I will start working on after this PR makes its way through.

### Todo After This PR Merges
- Apply similar logic for our mono-publish action proposed in [PR #33](https://github.com/thefrontside/actions/pull/33).
- Rerun workflows on [@bigtest/convergence PR#31](https://github.com/bigtestjs/convergence/pull/31) and [@bigtest/interactor PR#72](https://github.com/bigtestjs/interactor/pull/72).

### Test
I ran a separate action called `loggy` to test the logic of this PR (it's mainly a way for me to double check my shell syntax):
```
if [ !pull_request ]; then
  echo "This is not a pull request." // Scenario A
else
  if [ head_url = base_url ]; then
    echo "Action will continue." // Scenario B
  else
    echo "Action won't continue." // Scenario C
  fi
fi
```
- [On Push](https://github.com/minkimcello/georgia/runs/279872684#step:4:0) = Scenario A
![Screen Shot 2019-10-29 at 1 30 30 PM](https://user-images.githubusercontent.com/29791650/67792933-63c9ad80-fa50-11e9-8202-732ca58c1ffd.png)
- [On Pull Request](https://github.com/minkimcello/georgia/runs/279872886#step:4:0) = Scenario B
![Screen Shot 2019-10-29 at 1 30 42 PM](https://user-images.githubusercontent.com/29791650/67792947-688e6180-fa50-11e9-8d5b-99090eb15763.png)
- [On Pull Request from a Fork](https://github.com/taras/georgia/runs/279872872#step:4:0) = Scenario C
![Screen Shot 2019-10-29 at 1 30 49 PM](https://user-images.githubusercontent.com/29791650/67792963-6debac00-fa50-11e9-890c-0f252e464a52.png)

Update: I ran the action from this PR on Georgia. It's very messy but you can see [here](https://github.com/taras/georgia/pull/121) when the workflow succeeds (with our instructional message echoed in console) even though it's on a fork. And [here](https://github.com/minkimcello/georgia/pull/36) when the whole action runs on the pull request and posts a comment as well as when it runs on push so that workflow fails hence the :x::

![Screen Shot 2019-10-29 at 1 45 12 PM](https://user-images.githubusercontent.com/29791650/67794038-5e6d6280-fa52-11e9-9826-33e39fa1840b.png)
