### PR TITLE
Adding monorepo support to publish-pr-preview action

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ The following are our current actions. Go to its directories for a more detailed
 
 | Actions | Description |
 | ------- | ----------- |
-| [publish-pr-preview](/publish-pr-preview) | Publish preview package from pull request to NPM. |
+| [publish-pr-preview](/publish-pr-preview) | Publish preview package(s) from pull request to NPM. |
 | [synchronize-npm-tags](/synchronize-npm-tags) | Remove unwanted tags from NPM. |
 | [synchronize-with-npm](/synchronize-with-npm) | Push tag to Github and Publish to NPM. |

--- a/publish-pr-preview/Dockerfile
+++ b/publish-pr-preview/Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache git bash git-subtree jq
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["sh", "/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -1,14 +1,20 @@
 # Publish PR Preview
-This action will:
-- Check for accessibility to NPM token in secrets.
-- Make sure this action is being run from a pull request.
-- Make sure the name of the head branch of the pull request isn't `latest` to avoid conflicts with NPM tagging.
-- Update package version with snapshot, publish to NPM with branch name as tag.
-- Comment on pull request with instructions on how to access the package.
+This action will publish packages with the changes proposed in the pull request so that developers do not need for it to be reviewed, approved, and merged. Once the preview packages are published the action generates a comment with instructions on how to access the packages.
+
+## Monorepo Support
+This action now supports monorepos and will do all of the heavy lifting without burdening the developer with any complicated setup process. The action automatically detects which files have been modified and will only publish packages that have changes proposed as to not use up unnecessary resources.
 
 ## Requirements
-- Pass in `GITHUB_TOKEN` and `NPM_AUTH_TOKEN`.
-- Optional: `NPM_PUBLISH` argument is available if you want to run a different command. `npm publish` will run as default.
+- Meant to only run on a pull request
+- Pass in `GITHUB_TOKEN`
+- Pass in `NPM_AUTH_TOKEN`
+- Optional: Set `GPR` to true if you want to use Github Package Registry otherwise it will publish to `npmjs`
+  - Setting `GPR` to true would mean you do not need to pass in `NPM_AUTH_TOKEN`
+- Optional: `NPM_PUBLISH` argument is available if you want to run a different command
+  - `npm publish` will run as default
+- Optional: Specify `IGNORE` argument for directory of packages you don't want published for monorepos
+  - Directories specified in `.gitignore` won't be processed to begin with so for example if you don't want to include `./node_modules` and it's already included in your `.gitignore` file then there's no need to add it to the `IGNORE` arg in the workflow
+  - Root is intentionally not recognized as an argument because in the case of a monorepo it will automatically skip root during its publishing process. And for the case where it is a single repository, we should not be skipping root.
 
 ## Usage
 ```yaml
@@ -22,6 +28,7 @@ jobs:
       uses: thefrontside/actions/publish-pr-preview@master
       with:
         NPM_PUBLISH: npm run my-script
+        IGNORE: folder/example_package folder/example_package2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -1,20 +1,29 @@
 # Publish PR Preview
-This action will publish packages with the changes proposed in the pull request so that developers do not need for it to be reviewed, approved, and merged. Once the preview packages are published the action generates a comment with instructions on how to access the packages.
+`publish-pr-preview` will publish packages with the changes proposed in the pull request so that developers do not need for it to be reviewed, approved, and merged. Once the preview packages are published the action generates a comment with instructions on how to access the packages.
 
 ## Monorepo Support
 This action now supports monorepos and will do all of the heavy lifting without burdening the developer with any complicated setup process. The action automatically detects which files have been modified and will only publish packages that have changes proposed as to not use up unnecessary resources.
+
+## Package Registry
+The registry to which the packages will be published is determined by the `publishConfig` settings in the `package.json` file. If you wish to publish to `Github Package Registry`, please include the following in your `package.json` file for each of the packages in your repository:
+```
+{
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  }
+}
+```
+Without this configuration, the action will default to publishing to `npmjs` and will require `NPM_AUTH_TOKEN` to be passed in through the workflow.
 
 ## Requirements
 - Meant to only run on a pull request
 - Pass in `GITHUB_TOKEN`
 - Pass in `NPM_AUTH_TOKEN`
-- Optional: Set `GPR` to true if you want to use Github Package Registry otherwise it will publish to `npmjs`
-  - Setting `GPR` to true would mean you do not need to pass in `NPM_AUTH_TOKEN`
 - Optional: `NPM_PUBLISH` argument is available if you want to run a different command
   - `npm publish` will run as default
 - Optional: Specify `IGNORE` argument for directory of packages you don't want published for monorepos
   - Directories specified in `.gitignore` won't be processed to begin with so for example if you don't want to include `./node_modules` and it's already included in your `.gitignore` file then there's no need to add it to the `IGNORE` arg in the workflow
-  - Root is intentionally not recognized as an argument because in the case of a monorepo it will automatically skip root during its publishing process. And for the case where it is a single repository, we should not be skipping root.
+  - Packages that have sub-packages within its directory will intentionally skip during the publish process.
 
 ## Usage
 ```yaml

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -62,7 +62,7 @@ EOT
       json_within=($(find . -name 'package.json'));
       json_count=${#json_within[@]};
 
-      if [ "json_count" != "1" ]; then
+      if [ "$json_count" != "1" ]; then
         echo -e "${YELLOW}Skipping publishing process for: ${BLUE}$dir${YELLOW} because there is a sub-package.${NC}"
       else
         echo -e "${YELLOW}Running publishing process for: ${BLUE}$dir${YELLOW}.${NC}"

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -94,6 +94,8 @@ EOT
 
     pkgname="`node -e \"console.log(require('./package.json').name)\"`"
 
+    echo -e "${RED}count: $json_count"
+
     if [ "$json_count" != "1" ]; then
       echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because there is a sub-package.${NC}"
     else

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -4,6 +4,7 @@ set -e
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[1;34m'
 NC='\033[0m'
 
 function run_danger(){
@@ -51,7 +52,9 @@ EOT
   else
     install_with_CLI
     for dir in ${confirmed_packages[@]}; do
+      echo -e "${BLUE}$dir"
       cd $dir
+      echo -e "${YELLOW}$(ls)"
 
       authenticate_publish
       echo -e "${RED}Authenticated and proceeding..."

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -41,6 +41,8 @@ function publish(){
         echo $(jq --arg NAME "$pkgname" --arg DIRECTORY "$dir" '.error.name = $NAME | .error.directory = $DIRECTORY' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json 
         cd $GITHUB_WORKSPACE
 
+        echo $(jq '.' ./published.json)
+
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 const pjson = require('./published.json');
@@ -53,7 +55,7 @@ function already_published(){
   if(pjson.packages.length = 0){
     return '';
   } else if(pjson.packages.length = 1){
-    return `\nWe were able to publish \`${formatted}\`.\n${published.length} ${published[0]}`
+    return `\nWe were able to publish \`${formatted}\`.\n`
   } else {
     return `\nWe were able to publish these packages: \`${formatted}\`.\n`;
   }

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -151,7 +151,7 @@ function remove_packages_to_skip(){
   skip_directories=($(unslash_end_of_args $INPUT_IGNORE) ${defaults[@]})
   package_directories_array=(${package_directories[@]})
 
-  all_json=$(find . -name 'package.json');
+  all_json=($(find . -name 'package.json'));
   total_packages_count=${#all_json[@]};
 
   for skip_directory in ${skip_directories[@]}; do

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -23,7 +23,7 @@ function publish(){
   }
 
   function authenticate_publish(){
-    if [ $INPUT_GPR = true ]; then
+    if [[ $INPUT_GPR = true ]]; then
       echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > ~/.npmrc
     else
       echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -195,6 +195,7 @@ function remove_packages_to_skip(){
 
   for skip_directory in ${skip_directories[@]}; do
     for i in ${!confirmed_directories_array[@]}; do
+      echo -e "${RED}Checking ${YELLOW}$skip_directory${RED} against ${YELLOW}${confirmed_directories_array[$i]}"
       if [ $(echo "${confirmed_directories_array[$i]}" | sed -E "s:^$skip_directory.*::") ]; then
         :
       else

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -53,7 +53,7 @@ function already_published(){
   if(pjson.packages.length = 0){
     return '';
   } else if(pjson.packages.length = 1){
-    return `\nWe were able to publish \`${formatted}\`.\n`
+    return `\nWe were able to publish \`${formatted}\`.\n${published.length} ${published[0]}`
   } else {
     return `\nWe were able to publish these packages: \`${formatted}\`.\n`;
   }
@@ -189,13 +189,12 @@ function remove_packages_to_skip(){
     done;
   }
 
-  defaults=("node_modules" ".github")
+  defaults=("node_modules")
   skip_directories=($(unslash_end_of_args $INPUT_IGNORE) ${defaults[@]})
   confirmed_directories_array=(${confirmed_directories[@]})
 
   for skip_directory in ${skip_directories[@]}; do
     for i in ${!confirmed_directories_array[@]}; do
-      echo -e "${RED}Checking ${YELLOW}$skip_directory${RED} against ${YELLOW}${confirmed_directories_array[$i]}"
       if [ $(echo "${confirmed_directories_array[$i]}" | sed -E "s:^$skip_directory.*::") ]; then
         :
       else

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -62,7 +62,9 @@ EOT
       json_within=($(find . -name 'package.json'));
       json_count=${#json_within[@]};
 
-      if [ "json_count" = "1" ]; then
+      if [ "json_count" != "1" ]; then
+        echo -e "${YELLOW}Skipping publishing process for: ${BLUE}$dir${YELLOW} because there is a sub-package.${NC}"
+      else
         echo -e "${YELLOW}Running publishing process for: ${BLUE}$dir${YELLOW}.${NC}"
         authenticate_publish
         npm_version_SHA
@@ -76,8 +78,6 @@ EOT
         
         pkgname="`node -e \"console.log(require('./package.json').name)\"`"
         echo $(jq --arg PKG "$pkgname" '.packages[.packages | length] |= . + {"name": $PKG}' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json
-      else
-        echo -e "${YELLOW}Skipping publishing process for: ${BLUE}$dir${YELLOW} because there is a sub-package.${NC}"
       fi
 
       cd $GITHUB_WORKSPACE
@@ -187,7 +187,8 @@ function package_json_finder(){
   diff_directories=$(format_dit_giff $diffs)
   diff_directories_array=(${diff_directories[@]})
 
-  echo -e "${GREEN}Full list: ${BLUE}${diff_directories_array[@]}${NC}"
+  echo -e "${GREEN}Full diffs: ${BLUE}${diffs}${NC}"
+  echo -e "${GREEN}Full diffs formatted: ${BLUE}${diff_directories_array[@]}${NC}"
 
   package_directories=()
 
@@ -207,7 +208,7 @@ function package_json_finder(){
   }
 
   for i in ${!diff_directories_array[@]}; do 
-    echo -e "${RED}Running json_locator for: ${YELLOW}${diff_directories_array[$i]}${RED}.${NC}"
+    echo -e "${RED}Running json_locator for: ${YELLOW}${diff_directories_array[$i]}${RED} because of ${i}.${NC}"
     json_locater ${diff_directories_array[$i]}
   done;
 

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -99,13 +99,7 @@ cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 const pjson = require('./published.json');
 
-function packages(){
-  let stringy = "";
-  pjson.packages.map(x=>{
-    stringy += package(x.name)
-  })
-  return stringy;
-}
+let packages = pjson.packages.reduce((acc, item) => acc + package(item.name), '');
 
 function package(name){
   const first_line = `Install using the following command:`
@@ -136,7 +130,7 @@ function package(name){
 const first_line = `The packages of this pull request have been released to Github Package Registry.`;
 const second_line = `Click on the following packages for instructions on how to install them:`;
 
-markdown(`${first_line}\n${second_line}\n${packages()}`)
+markdown(`${first_line}\n${second_line}\n${packages}`)
 EOT
     fi;
   fi;

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -89,12 +89,10 @@ EOT
   for dir in ${confirmed_directories_array[@]}; do
     cd $dir
 
-    json_within=($(find . -name 'package.json'));
+    json_within=($(find . -name 'package.json' -not -path './node_modules/*'));
     json_count=${#json_within[@]};
 
     pkgname="`node -e \"console.log(require('./package.json').name)\"`"
-
-    echo -e "${RED}count: $json_count"
 
     if [ "$json_count" != "1" ]; then
       echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because there is a sub-package.${NC}"

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 RED='\033[1;31m'
@@ -6,54 +6,66 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+function run_danger(){
+  yarn global add danger --dev
+  export PATH="$(yarn global bin):$PATH"
+  danger ci
+}
 
-PR="$(jq '."pull_request"' ../workflow/event.json)"
-if [[ "$PR" = "null" ]]
-  then
-    echo -e "${RED}ERROR: We suspect this workflow was not triggered from a pull request.${NC}"
-    exit 1
+function publish(){
+  function install_with_CLI(){
+    if [ -f "yarn.lock" ]; then
+      yarn
+    else
+      npm config set unsafe-perm true
+      npm install
+    fi
+  }
 
-else
-  if [[ "$GITHUB_HEAD_REF" = "latest" ]]
-    then
-      echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
-      echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
+  function authenticate_publish(){
+    if [ $INPUT_GPR = true ]; then
+      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > ~/.npmrc
+    else
+      echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+    fi
+  }
 
-cat << "EOT" > dangerfile.js
-const { markdown } = require('danger');
-
-const first_line = `:warning: WARNING :warning:`;
-const second_line = `I can't publish a preview of this branch this because it would conflict with the \`latest\` tag which is [reserved by NPM](https://docs.npmjs.com/cli/dist-tag#purpose).`;
-
-markdown(`${first_line}\n\n${second_line}`)
-EOT
-
-  elif [ "${#NPM_AUTH_TOKEN}" -eq "0" ]
-    then
-      echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
-    
-cat << "EOT" > dangerfile.js
-const { markdown } = require('danger');
-
-const first_line = `:mega: Heads up!`;
-const second_line = `I didn't detect an NPM_AUTH_TOKEN which is necessary to publish a preview version of this package, and so I wasn't able to. However, this is perfectly normal for pull requests that are submitted from a forked repository, so no need to worry if that's what's going on here.`;
-
-markdown(`${first_line}\n\n${second_line}`)
-EOT
-
-  else
+  function npm_version_SHA(){
     npm version "`node -e \"console.log(require('./package.json').version)\"`-`git log --pretty=format:'%h' -n 1`" --no-git-tag-version
-    echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
-    npm config set unsafe-perm true
-    npm install
-    tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
-    if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]
-      then
+  }
+
+  tag="$(echo $GITHUB_HEAD_REF | sed -E 's:_:__:g;s:\/:_:g')"
+  echo '{"tag":"","packages":[]}' > published.json
+  echo $(jq --arg TEST "$tag" '.tag = $TEST' published.json) > published.json
+
+  if [ "${#confirmed_packages[@]}" -eq "0" ]; then 
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+
+const first_line = `:warning: NOTIFICATION :warning:`;
+const second_line = `You are receiving this message because there were no packages to publish..`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+  else
+    install_with_CLI
+    for dir in ${confirmed_packages[@]}; do
+      cd $dir
+
+      authenticate_publish
+      npm_version_SHA
+
+      if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]; then
         npm publish --access=public --tag $tag
       else
         $INPUT_NPM_PUBLISH --access=public --tag $tag
-    fi
-
+      fi
+      
+      pkgname="`node -e \"console.log(require('./package.json').name)\"`"
+      echo $(jq --arg PKG "$pkgname" '.packages[.packages | length] |= . + {"name": $PKG}' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json
+      cd $GITHUB_WORKSPACE
+    done;
+    if [ "${#confirmed_packages[@]}" -eq "1" ]; then
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 const pjson = require('./package.json');
@@ -73,21 +85,176 @@ const last_line = `Once the branch associated with this tag is deleted (usually 
 
 markdown(`${first_line}\n${second_line}\n\`\`\`bash\n${install_tag}\n\`\`\`\n${fourth_line}\n\`\`\`bash\n${update_json}\n\`\`\`\n${last_line}`)
 EOT
+    else
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+const pjson = require('./published.json');
 
-  fi
+function packages(){
+  let stringy = "";
+  pjson.packages.map(x=>{
+    stringy += package(x.name)
+  })
+  return stringy;
+}
 
-jsonpath="../workflow/event.json"
-headurl="$(jq '."pull_request"|."head"|."repo"|."url"' $jsonpath)"
-baseurl="$(jq '."pull_request"|."base"|."repo"|."url"' $jsonpath)"
+function package(name){
+  const first_line = `Install using the following command:`
+  const install_tag = `$ npm install ${name}@${pjson.tag}`
+  const or_line = `Or update your package.json file:`
+  const json_line = `\"${name}\": \"${pjson.tag}\"`
 
-  if [[ "$headurl" = "$baseurl" ]]; 
-  then
-    yarn global add danger --dev
-    export PATH="$(yarn global bin):$PATH"
-    danger ci
+  return `<details><summary>${name}</summary>
+  
+  ---
+  ${first_line}
+  
+  \`\`\`bash
+  ${install_tag}
+  \`\`\`
+  ${or_line}
+  
+  \`\`\`bash
+  {
+    ${json_line}
+  }
+  \`\`\`
+  
+  ---
+  </details>`
+}
+
+const first_line = `The packages of this pull request have been released to Github Package Registry.`;
+const second_line = `Click on the following packages for instructions on how to install them:`;
+
+markdown(`${first_line}\n${second_line}\n${packages()}`)
+EOT
+    fi;
+  fi;
+  run_danger
+}
+
+function remove_packages_to_skip(){
+  function unslash_end_of_args(){
+    for to_unslash in $*; do
+      echo $to_unslash | sed 's:\/$::g';
+    done;
+  }
+
+  defaults=("node_modules" ".github")
+  skip_directories=($(unslash_end_of_args $INPUT_IGNORE) ${defaults[@]})
+  package_directories_array=(${package_directories[@]})
+
+  all_json=$(find . -name 'package.json');
+  total_packages_count=${#all_json[@]};
+
+  for skip_directory in ${skip_directories[@]}; do
+    for i in ${!package_directories_array[@]}; do
+      if [ "${package_directories_array[$i]}" = "." ]; then
+        if [ "$total_packages_count" = "1" ]; then
+          :
+        else
+          unset package_directories_array[$i]
+        fi
+      else
+        if [ $(echo "${package_directories_array[$i]}" | sed -E "s:^$skip_directory.*::") ]; then
+          :
+        else
+          unset package_directories_array[$i]
+        fi
+      fi
+    done
+  done
+
+  confirmed_packages=($(echo "${package_directories_array[@]}" | xargs -n1 | sort -u | xargs))
+
+  publish
+}
+
+function package_json_finder(){
+  function format_dit_giff(){
+    for to_format in $*; do 
+      if [ "$(echo $to_format | grep -c "/")" = "0" ]; then 
+        echo ".";
+      else 
+        echo $(echo $to_format | sed 's:\(.*\)\/.*:\1:g');
+      fi;
+    done;
+  }
+  
+  git checkout $GITHUB_BASE_REF
+  git checkout $GITHUB_HEAD_REF
+
+  diffs=$(git diff --name-only $GITHUB_BASE_REF..$GITHUB_HEAD_REF)
+  diff_directories=$(format_dit_giff $diffs)
+  diff_directories_array=(${diff_directories[@]})
+
+  package_directories=()
+
+  function json_locater(){
+    cd $GITHUB_WORKSPACE/$1
+    if [ ! -f "package.json" ]; then
+      if [ "$(echo $1 | grep -c "/")" = "1" ]; then
+        super_directory=$(echo $1 | sed 's:\(.*\)\/.*:\1:g');
+        json_locater $super_directory
+      else
+        package_directories+=(".")
+      fi
+    else
+      package_directories+=("$1")
+    fi
+    cd $GITHUB_WORKSPACE
+  }
+
+  for i in ${!diff_directories_array[@]}; do 
+    json_locater ${diff_directories_array[$i]}
+  done;
+
+  remove_packages_to_skip
+}
+
+function check_prerequisites(){
+  PR="$(jq '."pull_request"' ../workflow/event.json)"
+  jsonpath="../workflow/event.json"
+  headurl="$(jq '."pull_request"|."head"|."repo"|."url"' $jsonpath)"
+  baseurl="$(jq '."pull_request"|."base"|."repo"|."url"' $jsonpath)"
+  
+  if [[ "$PR" = "null" ]]; then
+    echo -e "${RED}Not generating comment because this is not a pull request.${NC}"
   else
-    echo -e "${RED}Not generating a comment because this pull request was created from a forked repository.${NC}"
-    echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
-  fi
+    if [[ "$headurl" != "$baseurl" ]]; then
+      echo -e "${RED}Not generating a comment because this pull request was created from a forked repository.${NC}"
+      echo -e "${YELLOW}Publishing preview will not work if the pull request was created from a forked repository unless you create the pull request against your own repository.${NC}"
+    else
+      if [[ "$GITHUB_HEAD_REF" = "latest" ]]; then
+        echo -e "${RED}ERROR: Unable to publish preview because your branch conflicts with NPM's protected 'latest' tag.${NC}"
+        echo -e "${YELLOW}Please change the name of your branch and resubmit the pull request.${NC}"
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
 
-fi
+const first_line = `:warning: WARNING :warning:`;
+const second_line = `I can't publish a preview of this branch this because it would conflict with the \`latest\` tag which is [reserved by NPM](https://docs.npmjs.com/cli/dist-tag#purpose).`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+        run_danger
+      elif [ "${#INPUT_GPR}" -eq "0" ] && [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
+        echo -e "${RED}ERROR: NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
+    
+cat << "EOT" > dangerfile.js
+const { markdown } = require('danger');
+
+const first_line = `:mega: Heads up!`;
+const second_line = `I didn't detect an NPM_AUTH_TOKEN which is necessary to publish a preview version of this package, and so I wasn't able to. However, this is perfectly normal for pull requests that are submitted from a forked repository, so no need to worry if that's what's going on here.`;
+
+markdown(`${first_line}\n\n${second_line}`)
+EOT
+        run_danger
+      else
+        package_json_finder
+      fi
+    fi
+  fi
+}
+
+check_prerequisites

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -52,7 +52,7 @@ pjson.packages.map(x=>published.push(x.name));
 let formatted = published.join('\`, \`');
 
 function already_published(){
-  if(pjson.packages.length = 0){
+  if(pjson.packages.length = 0 || pjson.packages[0] == undefined){
     return '';
   } else if(pjson.packages.length = 1){
     return `\nWe were able to publish \`${formatted}\`.\n`

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -55,9 +55,9 @@ function already_published(){
   if(pjson.packages.length = 0 || pjson.packages[0] == undefined){
     return '';
   } else if(pjson.packages.length = 1){
-    return `\nWe were able to publish \`${formatted}\`.\n`
+    return `\nWe were able to publish \`${formatted}\`. However... \n`
   } else {
-    return `\nWe were able to publish these packages: \`${formatted}\`.\n`;
+    return `\nWe were able to publish these packages: \`${formatted}\`. However... \n`;
   }
 }
   
@@ -66,7 +66,7 @@ const first_solution = `\`\`\`yml\n# .github/workflows/your_workflow.yml\n\njobs
 const second_solution = `\`\`\`yml\n# ../${pjson.error.directory}/package.json\n\n{\n  \"name\": \"${pjson.error.name}\",\n  \"publishConfig\": \{\n    \"registry\": \"https://npm.pkg.github.com/\"\n  \}\n\}\n\`\`\``
 
 const first_line = `:warning: WARNING :warning:`;
-const second_line = `However, we were \*not\* able to publish \`${pjson.error.name}\` because of one of two reasons:`
+const second_line = `We were \*not\* able to publish \`${pjson.error.name}\` because of one of two reasons:`
 const third_line = `1. You forgot to pass in \`NPM_AUTH_TOKEN\` in the workflow configuration:\n${first_solution}\n\n2. You meant to publish to \`Github Package Registry\` in which case you must configure the \`package.json\` file:\n${second_solution}`
 
 markdown(`${first_line}\n${already_published()}\n${second_line}\n\n${third_line}`)

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -24,6 +24,7 @@ function publish(){
 
   function authenticate_publish(){
     if [[ $INPUT_GPR = true ]]; then
+      echo -e "${RED}GPR authing"
       echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > ~/.npmrc
     else
       echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
@@ -53,9 +54,11 @@ EOT
       cd $dir
 
       authenticate_publish
+      echo -e "${RED}Authenticated and proceeding..."
       npm_version_SHA
 
       if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]; then
+        echo -e "${RED}Publishing..."
         npm publish --access=public --tag $tag
       else
         $INPUT_NPM_PUBLISH --access=public --tag $tag

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -254,7 +254,7 @@ EOT
 cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 
-const first_line = `:mega: Heads up!`;
+const first_line = `:warning: WARNING :warning:`;
 const second_line = `I couldn't detect a NPM_AUTH_TOKEN which is necessary to publish a preview version of this package, However, this is perfectly normal for pull requests that are submitted from a forked repository, so no need to worry if that's what's going on here.`;
 const third_line = `You do not need to pass in a NPM_AUTH_TOKEN if you wish to publish to Github Package Registry, but you will need to specify so in the workflow.`;
 


### PR DESCRIPTION
## Motivation
The purpose of this pull request is for implementing monorepo support for transparent publishing. The first iteration of monorepo support was put into a separate action but we were able to integrate those functionalities to our already-existing `publish-pr-preview`. This action will automatically detect whether or not it's a monorepo and will function accordingly.

## Approach
I believe the simplest way to display the flow of this action is with pseudocode:
```js
check_prerequisites() {
  if [ not a pull request or pull request is made from a fork ] {
    echo error
    if [ branch name is 'latest' ] {
      pr_comment(custom error message)
    }
  } else {
    package_json_finder()
  }
}

pacakge_json_finder() {
  for i in directories_from_diff {
    package_directories.add(i)
  }
  package_directories.remove_duplicates
  remove_packages_to_skip()
}

remove_packages_to_skip() {
  for skip in skip_directories {
    for i in package_directories {
      if [ beginning of i matches skip ] {
        package_directores.remove(i)
      }
    }
  }
  publish()
}

publish() {
  if [ !package_directories ] {
    pr_comment("no packages to publish")
  } else {
    yarn/npm-install
      // auto-detects which CLI to use based on `yarn.lock`
    for i in package_directories {
      cd to directory
      authenticate(){
        // auto-detects which registry to use based on `publishConfig` settings
        if [ publishConfig.registry != GPR && !npm_token ] {
          pr_comment(custom_error_message)
        }
      }
      npm version version-{SHA}
      npm publish --tag branch_name
      published_packages.add(i)
    }
    if [ published_packages.length = 0 ] {
      pr_comment(zero published message)
    } else if [ published_packages.length = 1 ] {
      pr_comment(single repo message)
    } else {
      pr_comment(monorepo message)
    }
  }
}
```

### Changes to Publishing Single Repos
The current functionality of this action should not be any different after this pull request is merged. The workflow was as follows:
- Proceed only if it's a pull request
- Make sure the pull request isn't from a fork
- Make sure the branch name of head ref is not `latest`
- Yarn and update package version with SHA
- Publish using branch name as its tag
- Generate instructional comment on how to access preview package

All of those steps have been merged into the monorepo action workflow. The conditionals from preventing the action from resuming is placed in `check_prerequisites()`, and the commands related to publishing and generating the instructional comment are inside `publish()`.

The differences are:
- ✨ New Feature ✨: `yarn`/`npm install` is chosen automatically depending on whether or not there is `yarn.lock` file present at root. 😎 
- ~~In the case where there are multiple packages (monorepo), we prevent the root folder from publishing. But when there's only one package to publish and there's only one package.json in the whole repository, then we allow for root to be published.~~
  - ~~`What if it's a monorepo and there's only one package.json, we shouldn't allow it to publish root, right?`~~
    - ~~Either the package is in a subdirectory from the root so allowing root to publish won't have any affect. Or if there's only one `package.json` and it's on root... then it's probably not a monorepo quite yet.~~
  - 💥 New New Feature 💥: Packages that have sub-packages within them will not be published.
- ~~✨ New Feature ✨: Now the action takes in an argument for projects that wants to use `Github Package Registry`. Without the argument the default registry will be `npmjs`~~.
  - 💥 New New Feature 💥: No more arguments for `GPR` users. The action will automatically detect which package registry it should publish to.
- ✨ New Feature ✨: The comment generated on the pull request after successfully publishing the preview packages will either use the multi-package template or single-package template depending on how many packages were published. 😎 
  - 💥 New New Feature 💥: New template for when the registry is assumed to be `npmjs` and there is no `npm_auth_token` accessible:

![Screen Shot 2019-11-13 at 1 12 23 AM](https://user-images.githubusercontent.com/29791650/68737906-d5f2d400-05b2-11ea-9c04-8ffe0d5b0978.png)

## TODOs
- [ ] Should sub-packages of a monorepo run `yarn`/`npm-install` before publishing? @cowboyd 
- [x] Run all the tests below to double check for any errors.
- [x] Add colourful error messages and proofread message contents.
- [x] Update [PR #210](https://github.com/resideo/zeus/pull/210) on `resideo/zeus` to be more instructional.
- [x] Close PR #33.

## Tests/Learning
- [x] Test each scenario listed below:
  - [x] Trigger warning for when the action is not run on a pull request
  - [x] Trigger warning for when pull request is made from a fork
  - [x] Trigger warning for when branch is 'latest'
  - [x] Trigger warning when there's no `NPM_AUTH_TOKEN` (when registry is npm)
  - [x] Commit files to root only in a monorepo to confirm it skips publishing root
  - [x] Commit one file to root in a single repository to confirm it doesn't skip publishing root
  - [x] Commit one file to publish one package in a monorepo
  - [x] Add multiple files within one package of a monorepo to confirm it does not publish the same package multiple times
  - [x] Add files in the same directory as the argument specified to ignore publishing to confirm it does not publish
  - [x] Add files to multiple packages in a monorepo to confirm it publishes everything as intended
  - [x] Run action with `yarn.lock` to opt for `yarn install`
  - [x] Run action without `yarn.lock` to use `npm install`
  - [x] Run action with `input_gpr=true` to authenticate with `gpr`
  - [x] Run action without `input_gpr` to authenticate with `npm`
  - [x] Run action with `input_gpr=typo` to authenticate with `npm`
- [x] Rerun workflow on `microstates.js`: [PR #387](https://github.com/microstates/microstates.js/pull/387)
  - [x] 🌟 Re-rerun workflow on `microstates.js`
    - [x] Confirm `npmjs` publishing
    - [x] Run without `NPM_AUTH_TOKEN` to trigger error message
- [x] Rerun workflow on `effection.js`: [PR #25](https://github.com/thefrontside/effection.js/pull/25)
- [x] Rerun workflow on `resideo/zeus` [PR  #210](https://github.com/resideo/zeus/pull/210).
  - [x] 🌟 Re-rerun workflow on `resideo/zeus`
    - [x] Run normally to confirm `publishConfig` conditional works to use `gpr` as registry
    - [x] Remove `publishConfig` on one of the packages to force trigger error message
    - [x] Add sub-directory to one of the packages to prevent it from publishing in filter