### PR TITLE
Change location of .npmrc for authentication

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -31,7 +31,7 @@ function publish(){
     gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
     if [ "$gpr_publish_config" = true ]; then
       echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > ~/.npmrc
+      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ./.npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -74,7 +74,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ./.npmrc
       fi
     fi
   }

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -31,7 +31,7 @@ function publish(){
     gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
     if [ "$gpr_publish_config" = true ]; then
       echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ./.npmrc
+      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> .npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -74,7 +74,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ./.npmrc
+        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> .npmrc
       fi
     fi
   }


### PR DESCRIPTION
## Motivation
The `publish-pr-preview` action is overwriting authentication to the root of the repository and replacing the `.npmrc` file for each time it tries to publish a package. Although this has not caused any issues for us _yet_, if there were any projects with settings specified in their `~/.npmrc` file, this action would effectively erase those configurations (for the duration of the workflow).

## Approach
Once merged `publish-pr-preview` will instead authenticate to the directory of each of the package that it tries to publish by appending and not overwriting. Appending to the directory of the package is the obvious choice because if there were any conflicting configurations on the directory of the package in the repository already, those configurations will take precedence over whatever we append to in the root of the repository.