### PR TITLE
Add .github to ignore by default for publish-pr-preview

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -191,7 +191,7 @@ function remove_packages_to_skip(){
     done;
   }
 
-  defaults=("node_modules")
+  defaults=("node_modules .github")
   skip_directories=($(unslash_end_of_args $INPUT_IGNORE) ${defaults[@]})
   confirmed_directories_array=(${confirmed_directories[@]})
 


### PR DESCRIPTION
## Motivation
While doing test-runs of a prototype action on `georgia`, I inadvertently came across a scenario where I had a Javascript action in the `.github/` directory. Because Javascript actions have `package.json` files and those files were showing up in `git diff`, it tried to publish the action.

## Approach
I added .`github` as one of the default directories to ignore when `publish-pr-preview` tries to publish packages. Presumably this should not cause any conflicts in other use cases because packages and projects aren't often stored inside the `.github/` directory. The advantage it provides is I assume there might be other developers out there like myself who keeps their prototype actions all within the `.github/` directory for organizational purposes because the workflows folder is in there already as well.