### PR TITLE
Skip deleted directories to prevent error

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -232,18 +232,22 @@ function package_json_finder(){
   package_directories=()
 
   function json_locater(){
-    cd $GITHUB_WORKSPACE/$1
-    if [ ! -f "package.json" ]; then
-      if [ "$(echo $1 | grep -c "/")" = "1" ]; then
-        super_directory=$(echo $1 | sed 's:\(.*\)\/.*:\1:g');
-        json_locater $super_directory
+    if [ -d "${GITHUB_WORKSPACE}/${1}" ]; then
+      cd $GITHUB_WORKSPACE/$1
+      if [ ! -f "package.json" ]; then
+        if [ "$(echo $1 | grep -c "/")" = "1" ]; then
+          super_directory=$(echo $1 | sed 's:\(.*\)\/.*:\1:g');
+          json_locater $super_directory
+        else
+          package_directories+=(".")
+        fi
       else
-        package_directories+=(".")
+        package_directories+=("$1")
       fi
+      cd $GITHUB_WORKSPACE
     else
-      package_directories+=("$1")
+      echo -e "${RED}Skipping ${YELLOW}$1${RED} because the directory does not exist.${NC}"
     fi
-    cd $GITHUB_WORKSPACE
   }
 
   for i in ${!diff_directories_array[@]}; do 


### PR DESCRIPTION
## Motivation
While testing actions on `georgia`, I came across another scenario that I overlooked for the `publish-pr-preview` action. Deleted files show up in `git diff` and will cause an error because it is processed like any other directory in the action.

## Approach
The `publish-pr-preview` first starts by checking prerequisites to see if the action should run. Afterwards, it takes the results of `git diff` and searches for `package.json` for each `git diff`. I put an `if` to evaluate if the directory exists inside the function that looks for `package.json`.
- If directory exists it'll resume doing what it's supposed to.
- If the directory does not exist it will not be added to the array that's used for the remainder of the action.

## Todo
- [ ] I have not tested it but should I also modify `git diff` to `git diff --diff-filter=d` so that the directories of deleted files are not fed into the action?
  - The new `if` proposed in this pull request should catch them regardless but still...