### PR TITLE
Relocate `npm config unsafe-perm`

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -17,12 +17,12 @@ function run_danger(){
 
 function publish(){
   function install_with_CLI(){
+    npm config set unsafe-perm true
     if [ -f "yarn.lock" ]; then
       echo -e "${YELLOW}Running yarn...${NC}"
       yarn
     else
       echo -e "${YELLOW}Running npm...${NC}"
-      npm config set unsafe-perm true
       npm install
     fi
   }

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -31,7 +31,7 @@ function publish(){
     gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
     if [ "$gpr_publish_config" = true ]; then
       echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > ~/.npmrc
+      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ./.npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -74,7 +74,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ./.npmrc
       fi
     fi
   }

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -31,7 +31,7 @@ function publish(){
     gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
     if [ "$gpr_publish_config" = true ]; then
       echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ./.npmrc
+      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ~/.npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -74,7 +74,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ./.npmrc
+        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ~/.npmrc
       fi
     fi
   }

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -31,7 +31,7 @@ function publish(){
     gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
     if [ "$gpr_publish_config" = true ]; then
       echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> ~/.npmrc
+      echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" > ~/.npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -74,7 +74,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" >> ~/.npmrc
+        echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
       fi
     fi
   }


### PR DESCRIPTION
## Motivation
Action was not building packages; an issue that was already addressed [here](https://github.com/thefrontside/actions/pull/16).

## Approach
I relocated `npm config set unsafe-perm true` to run before `yarn` *and* `npm` as opposed to just `npm`.

## Test
I ran the action in this [PR](https://github.com/resideo/zeus/pull/231) for zeus and confirmed its proper functionality by installing the preview package and seeing the files we want inside `node_modules`.