### PR TITLE
Add python, make, g++ for publish-pr-preview

### DIFF
--- a/publish-pr-preview/Dockerfile
+++ b/publish-pr-preview/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --no-cache git bash git-subtree jq
+RUN apk add --no-cache git bash git-subtree jq python make g++
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
## Motivation
There are some node dependencies from `resideo/blueprint` that requires `python`, `make`, and `g++` in the Dockerfile in order to build properly in its workflow.

## Approach
The three packages that are added to the dockerfile of `publish-pr-preview` extends the build time of this action to 16 seconds (from 8 seconds). The same three packages were also added to the temporary `publish-releases` action on `minkimcello/actions`.

## Tests
The following workflows were run on `resideo/blueprint`:
- Without `python`, `make`, and `g++`: [316895696](https://github.com/resideo/blueprint/commit/59c960762be7601b51a0870b49c42d5d3979b94b/checks?check_suite_id=316895696) 👎 
- With `python`, `make`, and `g++`: [316870393](https://github.com/resideo/blueprint/commit/1ad4af6141b3682f6477e7a4e093a5ec36afd2ed/checks?check_suite_id=316870393) 👍 