### PR TITLE
Allow user to choose registry for publishing for publish-pr-preview

### DIFF
--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -45,7 +45,7 @@ jobs:
         NPM_PUBLISH: npm run my-script
         REGISTRY: https://npm.pkg.github.com
         IGNORE: folder/example_package folder/example_package2
-        SCOPES: minkimcello@npm thefrontisde@gpr
+        SCOPES: minkimcello@npm thefrontside@gpr
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -5,7 +5,7 @@
 This action now supports monorepos and will do all of the heavy lifting without burdening the developer with any complicated setup process. The action automatically detects which files have been modified and will only publish packages that have changes proposed as to not use up unnecessary resources.
 
 ## Registry
-This action will publish to `npmjs` by default but you can specify to which registry you want to publish by using the `REGISTRY` argument in your workflow. See `USAGE` for example.
+This action will publish to `npmjs` by default but you can specify to which registry you want to publish by using the `REGISTRY` argument in your workflow. The user-specified registry will authenticate with `GITHUB_TOKEN` so you will need to pass in your own personal access token in the workflow. See example in `USAGE` below.
 
 This is not to be mistaken with the `SCOPES` argument which is for retrieving packages from private organizations and does not have anything to do with publishing.
 

--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -4,22 +4,15 @@
 ## Monorepo Support
 This action now supports monorepos and will do all of the heavy lifting without burdening the developer with any complicated setup process. The action automatically detects which files have been modified and will only publish packages that have changes proposed as to not use up unnecessary resources.
 
-## Package Registry
-The registry to which the packages will be published is determined by the `publishConfig` settings in the `package.json` file. If you wish to publish to `Github Package Registry`, please include the following in your `package.json` file for each of the packages in your repository:
-```
-{
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  }
-}
-```
-Without this configuration, the action will default to publishing to `npmjs` and will require `NPM_AUTH_TOKEN` to be passed in through the workflow.
+## Registry
+This action will publish to `npmjs` by default but you can specify to which registry you want to publish by using the `REGISTRY` argument in your workflow. See `USAGE` for example.
 
 This is not to be mistaken with the `SCOPES` argument which is for retrieving packages from private organizations and does not have anything to do with publishing.
 
 ## Requirements
 - Meant to only run on a pull request
 - Pass in `GITHUB_TOKEN` (but see `Private Dependencies` below)
+- Optional: Specify `REGISTRY` argument for which registry you want this action to publish.
 - Optional: Specify `IGNORE` argument for directory of packages you don't want published for monorepos
   - Directories specified in `.gitignore` won't be processed to begin with so for example if you don't want to include `./node_modules` and it's already included in your `.gitignore` file then there's no need to add it to the `IGNORE` arg in the workflow
   - Packages that have sub-packages within its directory will intentionally skip during the publish process.
@@ -50,6 +43,7 @@ jobs:
       uses: thefrontside/actions/publish-pr-preview@master
       with:
         NPM_PUBLISH: npm run my-script
+        REGISTRY: https://npm.pkg.github.com
         IGNORE: folder/example_package folder/example_package2
         SCOPES: minkimcello@npm thefrontisde@gpr
       env:

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -23,33 +23,33 @@ function publish(){
       name=$(echo $scope | sed "s:@.*::")
       if [ "$registry" = "gpr" ]; then
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
-        echo "@$name:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+        echo "@$name:registry=https://npm.pkg.github.com" >> ~/.npmrc
       elif [ "$registry" = "npm" ]; then
         if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
           echo -e "${RED}ERROR: ${YELLOW}NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
           echo -e "${BLUE}Tip: ${YELLOW}If you meant to publish to Github Package Registry, you must specify so in the package.json file.${NC}"
           exit 1
         else
-          echo "@${name}:registry=https://registry.npmjs.org/" >> ~/.npmrc
+          echo "@${name}:registry=https://registry.npmjs.org" >> ~/.npmrc
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
         fi
       fi
     done;
     if [ -f "yarn.lock" ]; then
-      echo -e "${YELLOW}Running yarn...${NC}"
+      echo -e "${YELLOW}Installing using yarn...${NC}"
       yarn
     else
-      echo -e "${YELLOW}Running npm...${NC}"
+      echo -e "${YELLOW}Installing using npm...${NC}"
       npm install
     fi
   }
 
   function authenticate_publish(){
-    gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
-    if [ "$gpr_publish_config" = true ]; then
-      echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "registry=https://npm.pkg.github.com/" >> .npmrc
-      echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+    if [ ! "${#INPUT_REGISTRY}" -eq "0" ]; then 
+      registry_unslashed=$(echo ${INPUT_REGISTRY} | sed 's:\/$::' | sed 's:.*\/\/:\/\/:')
+      echo -e "${GREEN}Authenticating for ${YELLOW}$registry_unslashed${NC}"
+      echo "registry=${INPUT_REGISTRY}" >> .npmrc
+      echo "${registry_unslashed}/:_authToken=${GITHUB_TOKEN}" >> .npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -81,18 +81,18 @@ function already_published(){
   
 const first_solution = `\`\`\`yml\n# .github/workflows/your_workflow.yml\n\njobs:\n  job-name:\n    name: Job Name\n    runs-on: ubuntu-latest\n    steps:\n    - uses: actions/checkout@v1\n    - uses: thefrontside/actions/publish-pr-preview@master\n      env:\n      NPM_AUTH_TOKEN: \$\{\{ secrets.NPM_AUTH_TOKEN \}\}\n\`\`\``
 
-const second_solution = `\`\`\`yml\n# ../${pjson.error.directory}/package.json\n\n{\n  \"name\": \"${pjson.error.name}\",\n  \"publishConfig\": \{\n    \"registry\": \"https://npm.pkg.github.com/\"\n  \}\n\}\n\`\`\``
+const second_solution = `\`\`\`yml\n# .github/workflows/your_workflow.yml\n\njobs:\n  job-name:\n    name: Job Name\n    runs-on: ubuntu-latest\n    steps:\n    - uses: actions/checkout@v1\n    - uses: thefrontside/actions/publish-pr-preview@master\n      with:\n      REGISTRY: https:\/\/npm.pkg.github.com\n\`\`\``
 
 const first_line = `:warning: WARNING :warning:`;
 const second_line = `We were \*not\* able to publish \`${pjson.error.name}\` because of one of two reasons:`
-const third_line = `1. You forgot to pass in \`NPM_AUTH_TOKEN\` in the workflow configuration:\n${first_solution}\n\n2. You meant to publish to \`Github Package Registry\` in which case you must configure the \`package.json\` file:\n${second_solution}`
+const third_line = `1. You forgot to pass in \`NPM_AUTH_TOKEN\` in the workflow configuration:\n${first_solution}\n\n2. You meant to publish to a different registry in which case you must pass in the \`REGISTRY\` argument in your workflow file:\n${second_solution}`
 
 markdown(`${first_line}\n${already_published()}\n${second_line}\n\n${third_line}`)
 EOT
         run_danger
         exit 1
       else
-        echo "registry=https://registry.npmjs.org/" >> .npmrc
+        echo "registry=https://registry.npmjs.org" >> .npmrc
         echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
       fi
     fi

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -22,16 +22,16 @@ function publish(){
       registry=$(echo $scope | sed "s:.*@::")
       name=$(echo $scope | sed "s:@.*::")
       if [ "$registry" = "gpr" ]; then
-        echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
-        echo "@$name:registry=https://npm.pkg.github.com/" >> ~/.npmrc
+        echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+        echo "@$name:registry=https://npm.pkg.github.com/" >> .npmrc
       elif [ "$registry" = "npm" ]; then
         if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
           echo -e "${RED}ERROR: ${YELLOW}NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
           echo -e "${BLUE}Tip: ${YELLOW}If you meant to publish to Github Package Registry, you must specify so in the package.json file.${NC}"
           exit 1
         else
-          echo "@${name}:registry=https://registry.npmjs.org/" >> ~/.npmrc
-          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
+          echo "@${name}:registry=https://registry.npmjs.org/" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
         fi
       fi
     done;

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -23,14 +23,14 @@ function publish(){
       name=$(echo $scope | sed "s:@.*::")
       if [ "$registry" = "gpr" ]; then
         echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
-        echo "@$name:registry=https://npm.pkg.github.com" >> ~/.npmrc
+        echo "@$name:registry=https://npm.pkg.github.com/" >> ~/.npmrc
       elif [ "$registry" = "npm" ]; then
         if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
           echo -e "${RED}ERROR: ${YELLOW}NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
           echo -e "${BLUE}Tip: ${YELLOW}If you meant to publish to Github Package Registry, you must specify so in the package.json file.${NC}"
           exit 1
         else
-          echo "@${name}:registry=https://registry.npmjs.org" >> ~/.npmrc
+          echo "@${name}:registry=https://registry.npmjs.org/" >> ~/.npmrc
           echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
         fi
       fi

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -48,8 +48,8 @@ function publish(){
     if [ ! "${#INPUT_REGISTRY}" -eq "0" ]; then 
       registry_formatted=$(echo ${INPUT_REGISTRY} | sed 's:\/$::' | sed 's:.*\/\/:\/\/:')
       echo -e "${GREEN}Authenticating for ${YELLOW}$registry_formatted${NC}"
-      echo "registry=${INPUT_REGISTRY}" >> .npmrc # temporary until PR #43
-      echo "${registry_formatted}/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+      echo "registry=${INPUT_REGISTRY}" >> ~/.npmrc # temporary until PR #43
+      echo "${registry_formatted}/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -92,8 +92,8 @@ EOT
         run_danger
         exit 1
       else
-        echo "registry=https://registry.npmjs.org/" >> .npmrc
-        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
+        echo "registry=https://registry.npmjs.org/" >> ~/.npmrc
+        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
       fi
     fi
   }

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -22,16 +22,16 @@ function publish(){
       registry=$(echo $scope | sed "s:.*@::")
       name=$(echo $scope | sed "s:@.*::")
       if [ "$registry" = "gpr" ]; then
-        echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
-        echo "@$name:registry=https://npm.pkg.github.com/" >> .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
+        echo "@$name:registry=https://npm.pkg.github.com/" >> ~/.npmrc
       elif [ "$registry" = "npm" ]; then
         if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
           echo -e "${RED}ERROR: ${YELLOW}NPM_AUTH_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
           echo -e "${BLUE}Tip: ${YELLOW}If you meant to publish to Github Package Registry, you must specify so in the package.json file.${NC}"
           exit 1
         else
-          echo "@${name}:registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
+          echo "@${name}:registry=https://registry.npmjs.org/" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
         fi
       fi
     done;

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -46,10 +46,10 @@ function publish(){
 
   function authenticate_publish(){
     if [ ! "${#INPUT_REGISTRY}" -eq "0" ]; then 
-      registry_unslashed=$(echo ${INPUT_REGISTRY} | sed 's:\/$::' | sed 's:.*\/\/:\/\/:')
-      echo -e "${GREEN}Authenticating for ${YELLOW}$registry_unslashed${NC}"
+      registry_formatted=$(echo ${INPUT_REGISTRY} | sed 's:\/$::' | sed 's:.*\/\/:\/\/:')
+      echo -e "${GREEN}Authenticating for ${YELLOW}$registry_formatted${NC}"
       echo "registry=${INPUT_REGISTRY}" >> .npmrc
-      echo "${registry_unslashed}/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+      echo "${registry_formatted}/:_authToken=${GITHUB_TOKEN}" >> .npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -92,7 +92,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "registry=https://registry.npmjs.org" >> .npmrc
+        echo "registry=https://registry.npmjs.org/" >> .npmrc
         echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
       fi
     fi

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -48,7 +48,7 @@ function publish(){
     if [ ! "${#INPUT_REGISTRY}" -eq "0" ]; then 
       registry_formatted=$(echo ${INPUT_REGISTRY} | sed 's:\/$::' | sed 's:.*\/\/:\/\/:')
       echo -e "${GREEN}Authenticating for ${YELLOW}$registry_formatted${NC}"
-      echo "registry=${INPUT_REGISTRY}" >> .npmrc
+      echo "registry=${INPUT_REGISTRY}" >> .npmrc # temporary until PR #43
       echo "${registry_formatted}/:_authToken=${GITHUB_TOKEN}" >> .npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"


### PR DESCRIPTION
## Motivation
So far we've been assessing the configuration settings inside `package.json` to determine which registry to use for publishing. However, while constructing a testing environment for our actions, we realized we needed to be able to manually specify to which registry we want to publish.

## Approach
### ✨ WHAT'S NEW? ✨ 
- `REGISTRY` argument can now be specified in the workflow file and the action will publish the preview packages from the pull request to that one registry.
  - The default registry is `npmjs` if user does not specify registry.
    - When publishing to the default registry, users will be expected to pass in `NPM_AUTH_TOKEN` through the workflow.
  - If the `REGISTRY` argument is used, the action will authenticate for that registry with `GITHUB_TOKEN`.
  - ⚠️ This now means the action can only publish to one registry per workflow. ⚠️ 
- ~~We are now scoping/authenticating to the `.npmrc` file of the current directory wherever that may be throughout the process of the action.~~
  - ~~Some projects/monorepos have `.npmrc` scattered here and there. We will avoid conflicts by authenticating and scoping to the nearest directory.~~
  - ❗️We've decided to authenticate/scope to the root of the repository.❗️
    - This means user-set configurations in the `.npmrc` files in their repository will take precedence.
- Updated README for the action. You can see it [here](https://github.com/minkimcello/actions/blob/mk/preview-auth/publish-pr-preview/README.md).
  - ❓ _Does README updates warrant a separate pull request?_ ❓
- Updated generated pull request comment to reflect the new changes.
- I left the `SCOPES` argument in because `Github Package Registry` does not seem to mirror public packages of the other major registries. Being explicit with the scopes that are necessary for packages of private dependencies seems to be right choice for now. 🤷‍♂ 

## Usage
Not all arguments are mandatory but this is now what the workflow configuration for `publish-pr-preview` can look like:
```yml
jobs:
  job_name:
    name: Job Name
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v1
    - name: Publish PR Preview
      uses: thefrontside/actions/publish-pr-preview@master
      with:
        NPM_PUBLISH: npm run my-script
        REGISTRY: https://npm.pkg.github.com
        IGNORE: folder/example_package folder/example_package2
        SCOPES: minkimcello@npm thefrontisde@gpr
      env:
        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
```

## TODOs
- [x] Create PR to update action on `zeus`: [PR #273](https://github.com/resideo/zeus/pull/273)
- [x] Update PR for `blueprint`[PR #12](https://github.com/resideo/blueprint/pull/12)