### PR TITLE
Fix unsafe-perm for custom publish script (publish-pr-prevew)

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -48,8 +48,7 @@ function publish(){
     gpr_publish_config=$(jq '."publishConfig"|."registry"' ./package.json | sed 's:.*npm.pkg.github.*:true:');
     if [ "$gpr_publish_config" = true ]; then
       echo -e "${GREEN}Authenticating for ${YELLOW}Github Package Registry${NC}"
-      echo "registry=https://npm.pkg.github.com/" >> .npmrc
-      echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> .npmrc
+      echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
     else
       echo -e "${GREEN}Authenticating for ${YELLOW}NPMjs${NC}"
       if [ "${#NPM_AUTH_TOKEN}" -eq "0" ]; then
@@ -92,8 +91,7 @@ EOT
         run_danger
         exit 1
       else
-        echo "registry=https://registry.npmjs.org/" >> .npmrc
-        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> .npmrc
+        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
       fi
     fi
   }
@@ -124,9 +122,9 @@ EOT
 
       echo -e "${GREEN}Publishing...${NC}"
       if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]; then
-        npm publish --access=public --tag $tag
+        npm_config_registry=$INPUT_REGISTRY npm_config_unsafe_perm="true" npm publish --access=public --tag $tag
       else
-        $INPUT_NPM_PUBLISH --access=public --tag $tag
+        npm_config_registry=$INPUT_REGISTRY npm_config_unsafe_perm="true" $INPUT_NPM_PUBLISH --access=public --tag $tag
       fi
       
       echo $(jq --arg PKG "$pkgname" '.packages[.packages | length] |= . + {"name": $PKG}' $GITHUB_WORKSPACE/published.json) > $GITHUB_WORKSPACE/published.json


### PR DESCRIPTION
## Motivation
By now it seemed like the actions were settling down but we keep coming across new issues. Our `preview workflow` in `effection.js` was returning an error whilst publishing. Upon assessing the issue, I was able to come up with a solution and it has to do with `unsafe-perm` once again.

## Approach
### Why it was 👎 
We were trying to accommodate for monorepo projects that contains `.npmrc` files within individual packages. Since `npm` CLI searches for the closest (not the right term but you know what I mean) `.npmrc` file, we appended authentication and registry information for each of the packages-to-be-published in its directory as opposed to root since any conflicting configurations on that directory will take precedence over the `.npmrc` file in root.

Prior to `yarn`/`npm install` on the root of the repository (before we get to the process where we actually publish the packages), we were setting `npm config set unsafe-perm true` to the `~/.npmrc` file. This worked fine for most use cases, however, we were getting an error for projects that specified `NPM_PUBLISH` argument in the workflow.

The reason was the current directory had an `.npmrc` file and so the `unsafe-perm true` from the root `~/.npmrc` was not being recognized. So I added `unsafe-perm true` to the directory from where we were attempting to publish. That proved to be problematic because:

>  If set explicitly to false, then installing as a non-root user will fail. // npmjs.org

The publishing script for `effection.js` is configured to `pack build`, `cd pkg`, and then `npm publish`. That means we need a `.npmrc` with the `unsafe-perm` option set in the `./pkg` directory for it to work. I've tested so and it does indeed work. However, we obviously shouldn't hard code `cd pkg`.

### Why it is now sort of 👍 
~~I've been debating what we should do about the `.npmrc` files and the solution I've come up with is to just remove them from the individual packages. This action will now remove the `.npmrc` file (if it exists) and authenticate/set-registry to the `~/.npmrc`. If it's at the root, the `unsafe-perm true` configuration is recognized throughout the whole repository.~~ 👎

To summarize, this PR adds the following:
- ~~Remove `.npmrc` from package directory if it exists~~ 👎
- ~~`.npmrc` config options like authentication and registry is now being set at root~~ 👎 
  - We're only authenticating in `~/.npmrc`. `unsafe-perm` and `registry` are being set as environment variables from within the action
- ~~New `if` conditional for scoping for dependencies for extra safety measures~~ 👎
  - Unnecessary

### Trade Offs
~~We'll need to re-evaluate this approach if there are any preexisting `.npmrc` files within a repository that has configurations other than `unsafe-perm`, `registry`, and authentication. Depending on the config, we might be able to solve those issues by appending individual package `.npmrc` files to the root and *then* authenticate/set-registry that way we catch any other config options. 🤷‍♂ We'll cross that bridge when we need to.~~

No trade offs.