### PR TITLE
Update synchronize-npm-tags

### DIFF
--- a/synchronize-npm-tags/README.md
+++ b/synchronize-npm-tags/README.md
@@ -1,5 +1,7 @@
 # Synchronize NPM Tags
-With the exception of `latest` and any other tag labels that are passed in as arguments, this action will remove tags from NPM that do not match any existing branch names.
+`synchronize-npm-tags` is part of our Transparent Publishing workflow and is meant to be triggered `on: delete`. This action will cross-reference the NPM dist-tags with branch names and remove the tags that we no longer need (with the exception of `latest` and any other tag labels that are passed in as the `preserve` argument).
+
+For instance, let's say we have a pull request that published a package with the tag of `foo-bar`. After we merge the pull request and delete the branch, this action will be triggered and see that "foo-bar" exists as a tag but there's no corresponding branch so it will remove that tag from the registry.
 
 ## Requirements
 - Pass in `NPM_TOKEN`.

--- a/synchronize-npm-tags/README.md
+++ b/synchronize-npm-tags/README.md
@@ -2,7 +2,7 @@
 With the exception of `latest` and any other tag labels that are passed in as arguments, this action will remove tags from NPM that do not match any existing branch names.
 
 ## Requirements
-- Pass in `NPM_AUTH_TOKEN`.
+- Pass in `NPM_TOKEN`.
 - Optional: You can specify any NPM tags you'd like to `preserve`.
 
 ## Usage
@@ -17,5 +17,5 @@ jobs:
       with:
         preserve: dev beta alpha
       env:
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```

--- a/synchronize-npm-tags/entrypoint.sh
+++ b/synchronize-npm-tags/entrypoint.sh
@@ -23,7 +23,7 @@ for tag in $npmtags; do
     then
       echo -e "${GREEN}Keeping tag, ${YELLOW}$tag${GREEN}, because it is protected.${NC}"
   else
-    echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+    echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
     npm dist-tag rm $package $tag
     echo -e "${RED}Removed tag, ${YELLOW}$tag${RED} from NPM because it did not match any existing branches.${NC}"
   fi


### PR DESCRIPTION
## Motivation
The `synchronize-npm-tags` action has been neglected for a while as we were focusing primarily on `publish-pr-preview` and `synchronize-with-npm` actions and the variable naming convention for `synchronize-npm-tags` became outdated from the other two actions.

### Context
The `synchronize-npm-tags` action will list all the tags from npmjs and cross-check with the branch names of the repository to see if the tags correspond to a branch name OR from user-specified list of tags to protect (i.e. dev, latest, alpha, beta...) which may not have a corresponding branch. It's meant to run triggered by `on: delete` any time a branch is deleted.

## Approach
I updated the variable name from `NPM_AUTH_TOKEN` to `NPM_TOKEN` and updated the README as well. What this means is we just need to change the workflow configuration to pass in the secret token as `NPM_TOKEN`. Like so: `env: NPM_TOKEN: ${{ secrets.WHATEVER }}`