### PR TITLE
Skip private packages for preview action

### DIFF
--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -42,11 +42,14 @@ function publish(){
 
     json_within=($(find . -name 'package.json' -not -path './node_modules/*'));
     json_count=${#json_within[@]};
+    is_private=$(echo $(jq '.private' package.json))
 
     pkgname="`node -e \"console.log(require('./package.json').name)\"`"
 
     if [ "$json_count" != "1" ]; then
       echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because there is a sub-package.${NC}"
+    elif [ "$is_private" = "true" ]; then
+      echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because package is marked as private and therefore not intended to be published.${NC}"
     else
       echo -e "${GREEN}Running publishing process for: ${YELLOW}$dir${NC}"
       npm_version_SHA


### PR DESCRIPTION
## Motivation
In preparation for refactoring our actions to Javascript, I wanted to update some of the things that have been left out while I was focusing on `@resideo/actions` so that while refactoring `thefrontside/actions` we do not leave those essential features out.

## Approach
The preview action does not know to skip private packages when publishing. NPM CLI will return an error and thus the workflow will return an error. By adding this conditional, the action will know to skip the package.

These changes aren't being proposed for a new release. It's just so that we don't forget to add these steps in the new refactored actions.