### PR TITLE
Add monorepo support for release action (synchronize-with-npm)

### DIFF
--- a/synchronize-with-npm/Dockerfile
+++ b/synchronize-with-npm/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12-alpine
 
-RUN apk add --no-cache git bash git-subtree
+RUN apk add --no-cache git bash git-subtree jq python make g++
 
 COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["sh", "/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/synchronize-with-npm/README.md
+++ b/synchronize-with-npm/README.md
@@ -1,10 +1,15 @@
 # Synchronize with NPM
-This action will push a tag to Github and then publish to NPM after it confirms the package version has not been published already.
+This action will automatically detect which packages of a monorepo have changed to determine which packages to publish (and works fine with single repositories too).
+
+The action will not publish packages that has a `package.json` within its sub-directories.
 
 ## Requirements
-- Pass in `GITHUB_TOKEN`. 
+- Pass in `secrets.GITHUB_TOKEN` into `GITHUB_TOKEN`.
+  - :exclamation: Must be `GITHUB_TOKEN` and not a personal access token of a bot. :exclamation:
 - Pass in `NPM_TOKEN`.
+- Optional: Specify `IGNORE` argument for directory of packages you don't want published.
 - Optional: `NPM_PUBLISH` argument is available if you want to run a different command. `npm publish` will run as default.
+  - :warning: However, if you provide this argument, it will run that script to publish for every package. :warning:
 
 ## Usage
 ```yaml

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 RED='\033[1;31m'
@@ -8,7 +8,7 @@ BLUE='\033[1;34m'
 NC='\033[0m'
 
 function git_setup(){
-  git remote set-url origin https://x-oauth-basic:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+  git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
   git fetch origin +refs/heads/*:refs/heads/*
 
   branch="${GITHUB_REF#*refs\/heads\/}"

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -4,39 +4,148 @@ set -e
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
+BLUE='\033[1;34m'
 NC='\033[0m'
 
-if [ "${#NPM_TOKEN}" -eq "0" ]
-  then
-    echo -e "${RED}NPM_TOKEN not detected. Please add your NPM Token to your repository's secrets.${NC}"
-  else 
-    version="`node -e \"console.log(require('./package.json').version)\"`"
-    package="`node -e \"console.log(require('./package.json').name)\"`"
-    if [ -z "$(npm view $package@$version)" ]
-      then
-        git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
-        git fetch origin +refs/heads/*:refs/heads/*
+function git_setup(){
+  git remote set-url origin https://x-oauth-basic:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+  git fetch origin +refs/heads/*:refs/heads/*
 
-        branch="${GITHUB_REF#*refs\/heads\/}"
-        git checkout $branch
+  branch="${GITHUB_REF#*refs\/heads\/}"
+  git checkout $branch
 
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-        git config user.name "$GITHUB_ACTOR"
-        
-        git tag --force "v$version"
-        git push --force  --tags "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY.git"
+  git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  git config user.name "$GITHUB_ACTOR"
+}
 
-        echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-        npm config set unsafe-perm true
-        npm install
-        if [ "${#INPUT_NPM_PUBLISH}" -eq "0" ]
-          then
-            npm publish --access=public
+function get_directories(){
+  function format_dit_giff(){
+    for to_format in $*; do 
+      if [ "$(echo $to_format | grep -c "/")" = "0" ]; then 
+        echo ".";
+      else 
+        echo $(echo $to_format | sed 's:\(.*\)\/.*:\1:g');
+      fi;
+    done;
+  }
+
+  function unslash_end(){
+    for to_unslash in $*; do
+      echo $to_unslash | sed 's:\/$::g';
+    done;
+  }
+
+  function json_locater(){
+    echo -e "${GREEN}Running json_locator for: ${YELLOW}$1${NC}"
+    if [ -d ${GITHUB_WORKSPACE}/$1 ]; then
+      cd $GITHUB_WORKSPACE/$1        
+      if [ ! -f "package.json" ]; then
+        if [ "$(echo $1 | grep -c "/")" = "1" ]; then
+          super_directory+=$(echo $1 | sed 's:\(.*\)\/.*:\1:g');
+          json_locater $super_directory
+        else
+          cd $GITHUB_WORKSPACE
+          json_within=($(find . -name 'package.json' -not -path './node_modules/*'));
+          json_count=${#json_within[@]};
+          if [ "$json_count" != "1" ]; then
+            echo -e "${RED}Excluding: ${YELLOW}.${RED} because there is a sub-package.${NC}"
           else
-            $INPUT_NPM_PUBLISH --access=public
+            package_directories+=(".")
+          fi
         fi
-        echo -e "${GREEN}Tagged and published version v${version} successfully!${NC}"
       else
-        echo -e "${YELLOW}Version $version of this package already exists. To publish the changes of this commit, you must update package version in the JSON file of your project.${NC}"
+        json_within=($(find . -name 'package.json' -not -path './node_modules/*'));
+        json_count=${#json_within[@]};
+        if [ "$json_count" != "1" ]; then
+          echo -e "${RED}Excluding: ${YELLOW}$1${RED} because there is a sub-package.${NC}"
+        else
+          package_directories+=("$1")
+        fi
+      fi
+      cd $GITHUB_WORKSPACE
+    else
+      echo -e "${RED}Skipping ${YELLOW}$1${RED} because the directory does not exist.${NC}"
     fi
-fi
+  }
+
+  function filter_ignores(){
+    defaults=("node_modules" ".github")
+    skip_directories=($(unslash_end $INPUT_IGNORE) ${defaults[@]})
+    for skip_directory in ${skip_directories[@]}; do
+      for i in ${!package_directories[@]}; do
+        if [ $(echo "${package_directories[$i]}" | sed -E "s:^$skip_directory.*::") ]; then
+          :
+        else
+          echo -e "${RED}Removing ${YELLOW}${package_directories[$i]} ${RED}because of ${YELLOW}${skip_directory}${NC}"
+          unset package_directories[$i]
+        fi
+      done
+    done
+  }
+
+  before=$(git --no-pager log --pretty=%P -n 1 $GITHUB_SHA)
+  current=$GITHUB_SHA
+  diff_directories=($(echo $(format_dit_giff $(git diff --name-only $before..$current)) | xargs -n1 | sort -u | xargs))
+  package_directories=()
+
+  for i in ${!diff_directories[@]}; do
+    json_locater ${diff_directories[$i]}
+  done
+
+  filter_ignores
+
+  publish_directories=($(echo ${package_directories[@]} | xargs -n1 | sort -u | xargs))
+}
+
+function publish(){
+  function install_with_CLI(){
+    if [ -f "yarn.lock" ]; then
+      echo -e "${YELLOW}Installing with yarn...${NC}"
+      npm_config_unsafe_perm=true yarn
+    else
+      echo -e "${YELLOW}Installing with npm...${NC}"
+      npm_config_unsafe_perm=true npm install
+    fi
+  }
+
+  function publish_command(){
+    if [ "${#INPUT_NPM_PUBLISH}" = "0" ]; then
+      npm publish
+    else
+      $INPUT_NPM_PUBLISH
+    fi
+  }
+
+  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+  echo "unsafe-perm=true" >> ~/.npmrc
+
+  install_with_CLI
+
+  for package in ${publish_directories[@]}; do
+    cd $GITHUB_WORKSPACE/$package
+
+    is_private=$(echo $(jq '.private' package.json))
+
+    if [ "$is_private" = "true" ]; then
+      echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because package is marked as private and therefore not intended to be published.${NC}"
+    else
+      package_name="`node -e \"console.log(require('./package.json').name)\"`"
+      version="`node -e \"console.log(require('./package.json').version)\"`"
+      echo -e "${GREEN}Running publishing process for: ${YELLOW}$package_name${NC}"
+
+      if [ -z "$(npm view ${package_name}@${version})" ]; then
+        publish_command --access=public
+        echo -e "${GREEN}Successfully published version ${BLUE}${version}${GREEN} of ${BLUE}${package_name}${GREEN}!${NC}"
+      else
+        echo -e "${RED}Version ${YELLOW}$version${RED} of ${YELLOW}$package_name${RED} already exists.${NC}"
+        echo -e "${BLUE}Tip:${YELLOW}To publish the changes of this commit, you must update package version in the package.json file.${NC}"
+      fi
+    fi
+
+    cd $GITHUB_WORKSPACE
+  done
+}
+
+git_setup
+get_directories
+publish


### PR DESCRIPTION
## Motivation
We need to update `synchronize-with-npm` action for the release workflow for `bigtest` by adding in monorepo support. `But we have no tests setup for our actions yet?` I know. But we also need a release workflow up and running for the bigtest update so this is better than nothing or being forced to manually publish.

## Approach
Monorepo support for this action has already been implemented in `resideo/actions` so I copied over the latest version of _that_ action and undid some of the resideo-specific configurations that were hard-coded.

## What's new?
Below are the changes made to `synchronize-with-npm`:
### This vs `publish-release` from `@resideo/actions`?
- Removed `remove_npmrc()` as none of our projects require pushing a `.npmrc` file to the repository at the moment.
- No longer manually authenticating for `github package registry`. By default, this action will use `npm_token` to authenticate for `npmjs`.

### This vs the old `synchronize-with-npm`?
- Monorepo support ⭐️
  - The action will do a git diff between the commit that triggered the action and the commit previous to that one and try and do a loop to publish all the packages that aren't filtered out through the various conditionals in the action.
    - Some of the conditionals include: if there are more than one `package.json` within that directory and sub-directories, if the directory falls under user-specified ignore argument, if the directory falls under the default ignore list (node_modules and .github), if the `package.json` is configured to be `private`
- The old action that was specifically for single repositories used to tag the release with the version from the `package.json`. We can no longer do that as multiple packages will have different version numbers and the monorepo itself would not have a version number.

## Todos AFTER this PR is merged
- Resolve [@bigtest/issue/127](https://github.com/thefrontside/bigtest/issues/127)
- Tag and release this repository as v1.3.
- Update bigtest workflow with the new tagged action.

## Todos BEFORE this PR is taken out of draft mode
- [x] Do test run on bigtest monorepo with ignore args and source the action from `mk/add-mono-rel` to confirm it publishes properly.
  - Successful run [here](https://github.com/thefrontside/bigtest/runs/454029814?check_suite_focus=true). Note to self: do `npm view @package` to check if publishing was successful because `npmjs.org` does not always update right away.