### PR TITLE
Add before_all argument for both release and preview actions

### DIFF
--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -12,7 +12,8 @@ This action now supports monorepos and will do all of the heavy lifting without 
   - Directories specified in `.gitignore` won't be processed to begin with so for example if you don't want to include `./node_modules` and it's already included in your `.gitignore` file then there's no need to add it to the `IGNORE` arg in the workflow
   - Packages that have sub-packages within its directory will intentionally skip during the publish process.
 - Optional: Passing in an argument for `NPM_PUBLISH` will run that command instead of `npm publish`.
-  - :warning: However, if you provide this argument, it will run that script to publish for every package (if you're running this action on a monorepo).
+  - :warning: However, if you provide this argument, it will run that script to publish for every package (if you're running this action on a monorepo). If you would need to run a custom command once for the repository and not each individual packages, use `BEFORE_ALL` (see below).
+- Optional: Passing in an argument for `BEFORE_ALL` will run that command after `npm install` or `yarn install` but before the action starts navigating into the different packages in the monorepo to start the publishign process.
 
 ### Private Dependencies
 If your project has package dependencies from private organizations, you must make sure that the repository is configured so it has access to those organizations.
@@ -31,6 +32,7 @@ jobs:
     - name: Publish PR Preview
       uses: thefrontside/actions/publish-pr-preview@master
       with:
+        BEFORE_ALL: npm run prepack-after-install
         NPM_PUBLISH: npm run my-script
         IGNORE: folder/example_package folder/example_package2
       env:

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -36,6 +36,11 @@ function publish(){
 
   install_with_CLI
   echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+  
+  if [ "${#INPUT_BEFORE_ALL}" -ne "0" ]; then
+    echo -e "${RED}Runnning before_all: ${YELLOW}$INPUT_BEFORE_ALL${RED}${NC}"
+    $INPUT_BEFORE_ALL
+  fi
 
   for dir in ${confirmed_directories_array[@]}; do
     cd $dir

--- a/synchronize-with-npm/README.md
+++ b/synchronize-with-npm/README.md
@@ -9,7 +9,8 @@ The action will not publish packages that has a `package.json` within its sub-di
 - Pass in `NPM_TOKEN`.
 - Optional: Specify `IGNORE` argument for directory of packages you don't want published.
 - Optional: `NPM_PUBLISH` argument is available if you want to run a different command. `npm publish` will run as default.
-  - :warning: However, if you provide this argument, it will run that script to publish for every package. :warning:
+  - :warning: However, if you provide this argument, it will run that script to publish for every package (if you're running this action on a monorepo). If you would need to run a custom command once for the repository and not each individual packages, use `BEFORE_ALL` (see below).
+- Optional: Passing in an argument for `BEFORE_ALL` will run that command after `npm install` or `yarn install` but before the action starts navigating into the different packages in the monorepo to start the publishign process.
 
 ## Usage
 ```yaml
@@ -22,7 +23,9 @@ jobs:
     - name: Syncrhonize with NPM
       uses: thefrontside/actions/synchronize-with-npm@master
       with:
+        BEFORE_ALL: npm run prepack-after-install
         NPM_PUBLISH: npm run my-script
+        IGNORE: packages/to/ignore
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -121,6 +121,11 @@ function publish(){
 
   install_with_CLI
 
+  if [ "${#INPUT_BEFORE_ALL}" -ne "0" ]; then
+    echo -e "${RED}Runnning before_all: ${YELLOW}$INPUT_BEFORE_ALL${RED}${NC}"
+    $INPUT_BEFORE_ALL
+  fi
+
   for package in ${publish_directories[@]}; do
     cd $GITHUB_WORKSPACE/$package
 


### PR DESCRIPTION
## Motivation
Sometimes the monorepo workflows need to run a command once for its entire monorepo and not for each individual package (which was the only available option prior to this pull request). We came across a use case for this new feature on [this](https://github.com/thefrontside/bigtest/pull/194) pull request on @thefrontside/bigtest where we needed to run `npm prepack` once for the entire monorepo and not for every package.

## Approach
Added `before_all` argument to both `publish-pr-preview` and `synchronize-with-npm` actions and updated its READMEs. 

The argument command will run after `yarn install` (or `npm install`) but before the action starts its loops for the individual packages.

## Tests
I test ran the action on [this](https://github.com/thefrontside/bigtest/pull/195) pull request from @thefrontside/bigtest.

The successful run can be found [here](https://github.com/thefrontside/bigtest/pull/195/checks?check_run_id=488192497). 
And the failing run prior to these changes can be seen [here](https://github.com/thefrontside/bigtest/runs/488061869).