### PR TITLE
Push git tags when pull request is merged to master

### DIFF
--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -8,7 +8,7 @@ BLUE='\033[1;34m'
 NC='\033[0m'
 
 function git_setup(){
-  git remote set-url origin https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git
+  git remote set-url origin https://x-oauth-basic:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
   git fetch origin +refs/heads/*:refs/heads/*
 
   branch="${GITHUB_REF#*refs\/heads\/}"

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -140,6 +140,8 @@ function publish(){
 
       if [ -z "$(npm view ${package_name}@${version})" ]; then
         publish_command --access=public
+        git tag $package_name-v$version
+        git push origin $package_name-v$version --tags
         echo -e "${GREEN}Successfully published version ${BLUE}${version}${GREEN} of ${BLUE}${package_name}${GREEN}!${NC}"
       else
         echo -e "${RED}Version ${YELLOW}$version${RED} of ${YELLOW}$package_name${RED} already exists.${NC}"

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -141,7 +141,7 @@ function publish(){
       if [ -z "$(npm view ${package_name}@${version})" ]; then
         publish_command --access=public
         git tag $package_name-v$version
-        git push origin $package_name-v$version --tags
+        git push origin $package_name-v$version
         echo -e "${GREEN}Successfully published version ${BLUE}${version}${GREEN} of ${BLUE}${package_name}${GREEN}!${NC}"
       else
         echo -e "${RED}Version ${YELLOW}$version${RED} of ${YELLOW}$package_name${RED} already exists.${NC}"


### PR DESCRIPTION
## Motivation
We have `synchronize-with-npm` action running in the release workflow of @thefrontside/bigtest. The action currently only publishes packages in the monorepo and does not yet push git tags with it which creates an extra barrier(?) when developers need to access specific iterations of a package.

## Approach
- Within the loop in the `synchronize-with-npm` action, I've added `git tag && git push --tags` *after* the package is published so that if the publishing isn't successful it won't push the tags
- Tags are generated in the format of `{package_name}-v{semver}` (e.g. `@bigtest/agent-v0.1.1`)
- Each tag is pushed per each loop in case another package fails to publish then the previous successfully-published packages wouldn't have its tags pushed
- Authentication for github was rearranged to match what we have over at resideo and also based on what worked and didn't work on @minkimcello/georgia; i'm not sure why i reversed it in the first place

## ToDoS
- [x] Do a test run of this new action on bigtest to see it works properly by running the release action from `thefrontside/actions/synchronize-with-npm@mk/tags`