### PR TITLE
Add deprecation logic into synchronize-with-npm

### DIFF
--- a/synchronize-with-npm/README.md
+++ b/synchronize-with-npm/README.md
@@ -3,6 +3,8 @@ This action will automatically detect which packages of a monorepo have changed 
 
 The action will not publish packages that has a `package.json` within its sub-directories.
 
+:star: NEW :star: deprecation feature: See below in `Deprecate Packages` section below.
+
 ## Requirements
 - Pass in `secrets.GITHUB_TOKEN` into `GITHUB_TOKEN`.
   - :exclamation: Must be `GITHUB_TOKEN` and not a personal access token of a bot. :exclamation:
@@ -30,3 +32,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```
+
+## Deprecate Packages
+When a package in a monorepo needs to be deprecated, this action will take care of that. All you need to do is add `"deprecate": true` inside the `package.json` of the package you wish to deprecate on NPM.

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -70,7 +70,7 @@ function get_directories(){
 
   function filter_ignores(){
     defaults=("node_modules" ".github")
-    skip_directories=($(unslash_end $INPUT_IGNORE) ${defaults[@]})
+    skip_directories=($(unslash_end $INPUT_IGNORE) ${defaults[@]} ${deprecate_paths[@]})
     for skip_directory in ${skip_directories[@]}; do
       for i in ${!package_directories[@]}; do
         if [ $(echo "${package_directories[$i]}" | sed -E "s:^$skip_directory.*::") ]; then
@@ -83,6 +83,16 @@ function get_directories(){
     done
   }
 
+  function packages_to_deprecate(){
+    all_package_jsons=($(find . -name 'package.json' -not -path '**/node_modules/**'))
+    for i in ${all_package_jsons[@]}; do
+      if [ "$(jq .deprecate $i)" == "true" ]; then
+        deprecate_paths+=($(echo $i | sed 's:\(.*\)\/.*:\1:g'));
+        deprecate_names+=("$(jq .name $i)");
+      fi
+    done;
+  }
+
   before=$(git --no-pager log --pretty=%P -n 1 $GITHUB_SHA)
   current=$GITHUB_SHA
   diff_directories=($(echo $(format_dit_giff $(git diff --name-only $before..$current)) | xargs -n1 | sort -u | xargs))
@@ -91,6 +101,10 @@ function get_directories(){
   for i in ${!diff_directories[@]}; do
     json_locater ${diff_directories[$i]}
   done
+
+  deprecate_paths=()
+  deprecate_names=()
+  packages_to_deprecate
 
   filter_ignores
 
@@ -153,6 +167,15 @@ function publish(){
   done
 }
 
+function deprecate(){
+  for to_deprecate in ${deprecate_names[@]}; do
+    echo -e "${RED}Deprecating${YELLOW} ${to_deprecate}${RED}...${NC}"
+    npm deprecate $to_deprecate "Package has been deprecated and is no longer supported."
+    echo -e "${GREEN}Deprecation of ${to_deprecate} complete.${NC}"
+  done
+}
+
 git_setup
 get_directories
 publish
+deprecate

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -87,7 +87,7 @@ function get_directories(){
     all_package_jsons=($(find . -name 'package.json' -not -path '**/node_modules/**'))
     for i in ${all_package_jsons[@]}; do
       if [ "$(jq .deprecate $i)" == "true" ]; then
-        deprecate_paths+=($(echo $i | sed 's:\(.*\)\/.*:\1:g'));
+        deprecate_paths+=($(echo $i | sed 's:\(.*\)\/.*:\1:g;s:^./::g'));
         deprecate_names+=("$(jq .name $i)");
       fi
     done;


### PR DESCRIPTION
⚠️ Note about deprecating NPM packages: the SHA-ified packages don't get deprecated for some reason unless it's done explicitly (i.e., versions that follow semver format (#.#.#) will be  covered but the packages we publish in our preview workflow (#.#.#-SHA) do not get deprecated with the `npm deprecate @thefrontside/package "Deprecate message"`).

![Screen Shot 2020-04-23 at 10 09 22 AM](https://user-images.githubusercontent.com/29791650/80108652-8560a900-854a-11ea-85c2-256a260362bb.png)

## Motivation
For whatever reason a package may need to be deprecated. Instead of deprecating it manually, we decided it would be best to incorporate it into our `synchronize-with-npm` action.

## Usage
1. Add `"deprecated": true` to the `package.json` of the package you'd like to deprecate.
2. Create pull request and merge to master to trigger `synchronize-with-npm` action.
3. Optional: Create another pull request to remove that package from the repository.

## Approach
![Screen Shot 2020-04-22 at 2 54 59 PM](https://user-images.githubusercontent.com/29791650/80023214-31eb4e00-84ab-11ea-80e0-0e0899e8cb60.png)
- The `get_directories` section is where most of the action's logic lies. It generates a list of packages to publish by seeing which ones have changed and afterwards filtering out the list by removing packages that should not be published (from the `ignore` argument and from the default list that includes `node_modules` and `.github`).
- In this new iteration of `synchronize-with-npm`, the action will look for every `package.json` to see if any of them has `"deprecated": true` property to compile a `packages-to-deprecate` list. ~~This list will be used for filtering out `packages-to-publish` and for the loop where we actually deprecate packages.~~ :warning: No we ain't. Regardless of whether we deprecate a package or not, we will publish it anyway.
- We had an alternate approach to this feature which was to detect which packages have been deleted and to auto-deprecate those packages. This approach would've shortened the usage into one step instead of having to create two pull requests (as outlined above) but there are several cases where we wouldn't want it to willynilly deprecate packages (e.g. if a package is moved to a different repository or is renamed). So it was our decision that it'd be better to be more explicit about which packages we want deprecated on NPM.

## TODOs
- [x] If say we want to deprecate a package, do we want the action to be able to publish that package one last time? (e.g. if we want to update the README to include deprecation notes before it's officially deprecate).
  - Answer: Yes.
- [x] Need to update README too once feature is finalized.

## Tests (WIP)
We still don't have an efficient way of testing actions so I will use [@minkimcello/georgia](https://github.com/minkimcello/georgia.git) to test this action thoroughly before taking this PR out of draft.
- Test results [here](https://github.com/minkimcello/georgia/runs/609490576?check_suite_focus=true)
  - Created a mixture of test scenarios (regular publish, not deprecate but ignore, deprecate and ignore, and just ignore) and the actions treated them in the way I expected.
- ⚠️ New test results that allows for packages-to-be-deprecated to be published too: [test](https://github.com/minkimcello/georgia/runs/609694057?check_suite_focus=true)