### PR TITLE
Remove quotations from package names for deprecating

### DIFF
--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -160,7 +160,7 @@ function deprecate(){
     all_package_jsons=($(find . -name 'package.json' -not -path '**/node_modules/**'))
     for i in ${all_package_jsons[@]}; do
       if [ "$(jq .deprecate $i)" == "true" ]; then
-        deprecate_names+=("$(jq .name $i)");
+        deprecate_names+=($(jq .name $i | sed 's/^"//g;s/"$//g'));
       fi
     done;
   }


### PR DESCRIPTION
## Motivation
The latest deprecation feature has a small bug which can be seen [here](https://github.com/thefrontside/bigtest/runs/612874846?check_suite_focus=true). We were passing in the names of the packages directly from the `package.json` property which is formatted with quotations but the `npm deprecate` command does not like that.

## Approach
Inside `synchronize-with-npm` the package names are being filtered so that any quotation marks at the beginning and end of the string is removed.