### PR TITLE
Use deprecate property in package.json as deprecate message

### DIFF
--- a/synchronize-with-npm/README.md
+++ b/synchronize-with-npm/README.md
@@ -34,4 +34,4 @@ jobs:
 ```
 
 ## Deprecate Packages
-When a package in a monorepo needs to be deprecated, this action will take care of that. All you need to do is add `"deprecate": true` inside the `package.json` of the package you wish to deprecate on NPM.
+When a package in a monorepo needs to be deprecated, this action will take care of that. All you need to do is add `"deprecate": "deprecation message"` inside the `package.json` of the package you wish to deprecate on NPM.

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -154,24 +154,17 @@ function publish(){
 }
 
 function deprecate(){
-  deprecate_names=()
-
-  function find_packages_to_deprecate(){
-    all_package_jsons=($(find . -name 'package.json' -not -path '**/node_modules/**'))
-    for i in ${all_package_jsons[@]}; do
-      if [ "$(jq .deprecate $i)" == "true" ]; then
-        deprecate_names+=($(jq .name $i | sed 's/^"//g;s/"$//g'));
-      fi
-    done;
-  }
-
-  find_packages_to_deprecate
+  all_package_jsons=($(find . -name 'package.json' -not -path '**/node_modules/**'))
   
-  for to_deprecate in ${deprecate_names[@]}; do
-    echo -e "${RED}Deprecating${YELLOW} ${to_deprecate}${RED}...${NC}"
-    npm deprecate $to_deprecate "Package has been deprecated and is no longer supported."
-    echo -e "${GREEN}Deprecation of ${to_deprecate} complete.${NC}"
-  done
+  for i in ${all_package_jsons[@]}; do
+    if [ "$(jq .deprecate $i)" != "null" ]; then
+      deprecate_name=$(jq .name $i | sed 's/^"//g;s/"$//g');
+      deprecate_description=$(jq .deprecate $i);
+      echo -e "${RED}Deprecating${YELLOW} ${deprecate_name}${RED}...${NC}"
+      npm deprecate $deprecate_name $deprecate_description
+      echo -e "${GREEN}Deprecation of ${deprecate_name} complete.${NC}"
+    fi
+  done;
 }
 
 git_setup


### PR DESCRIPTION
## Motivation
The third sequel to [PR #59]() and [PR #58](). Those two pull requests introduced a feature inside `synchronize-with-npm` that allows packages to be deprecated on npmjs. It required users to add `"deprecate": true` inside the `package.json`. However, instead of using a boolean, we could just add the deprecation message as the value to that property.

## Approach
- Changed up the logic of the `deprecate()` function.
- Updated README.
- Tested on `@minkimcello/georgia`.
- Will re-release as `v1.6`.