### PR TITLE
Validate instead of filter for synchronize-with-npm

### DIFF
--- a/synchronize-with-npm/README.md
+++ b/synchronize-with-npm/README.md
@@ -1,7 +1,5 @@
 # Synchronize with NPM
-This action will automatically detect which packages of a monorepo have changed to determine which packages to publish (and works fine with single repositories too).
-
-The action will not publish packages that has a `package.json` within its sub-directories.
+This action will review all the available packages and see if the user intends on publishing any of them by evaluating if the current package version exists.
 
 :star: NEW :star: deprecation feature: See below in `Deprecate Packages` section below.
 


### PR DESCRIPTION
## Motivation
When a pull request isn't squashed before it is merged it would compare the two latest commits from the pull request and not compare the whole pull request to master's latest commit. That resulted in `synchronize-with-npm` not knowing which packages it is supposed to publish. This made us re-evaluate the  workflow of the action.

This will resolve #49 and also resolve #61.

## Approach
### Previously
- The action determined which packages to publish by evaluating which files have been changed or created and looking for its relevant `package.json` file. 
  - Basically it was saying "only be allowed to publish if there are changes to the package... and also prevent it from publishing if it has any sub-packages".

### Proposed
- Pull up every `package.json` files (minus those inside `*/node_modules/*` and any directories specified via the `ignore` argument in the workflow file)
- Determine whether or not to publish based on:
  - check if `npm view package-name@version` exists
  - check if package is marked private
  - check if it has a version property or not in the `package.json`

### Summary
The function of the action is basically remaining the same except we've lifted some of the limitations and thus making the action even more robust. 
- We're keeping all the previous arguments: `before_all`, `npm_publish`, and `ignore`. 
- User is and was expected to bump the package version manually so that hasn't changed.

## Test
Was tested manually via `@minkimcello/georgia` but there are so many working parts that it's hard to find bugs until we run into them (or get testing set up) so we'll tag this as `v1.7` and give it a go until we run into issues.