### PR TITLE
Introduce yarn action

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ The following are our current actions. Go to its directories for a more detailed
 | [publish-pr-preview](/publish-pr-preview) | Publish preview package(s) from pull request to NPM. |
 | [synchronize-npm-tags](/synchronize-npm-tags) | Remove unwanted tags from NPM. |
 | [synchronize-with-npm](/synchronize-with-npm) | Push tag to Github and Publish to NPM. |
+| [yarn](/yarn) | Replace standard `yarn` command. |

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:12-alpine
+
+RUN apk add --no-cache bash
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,5 +1,5 @@
 # Yarn
-This action is to replace the standard `yarn` command so that the workflow will fail if there are any warnings.
+This action is to replace the standard `yarn` command so that the workflow will exit if there are any warnings.
 
 ## Usage
 ```yaml

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,0 +1,23 @@
+<!-- # Synchronize NPM Tags
+`synchronize-npm-tags` is part of our Transparent Publishing workflow and is meant to be triggered `on: delete`. This action will cross-reference the NPM dist-tags with branch names and remove the tags that we no longer need (with the exception of `latest` and any other tag labels that are passed in as the `preserve` argument).
+
+For instance, let's say we have a pull request that published a package with the tag of `foo-bar`. After we merge the pull request and delete the branch, this action will be triggered and see that "foo-bar" exists as a tag but there's no corresponding branch so it will remove that tag from the registry.
+
+## Requirements
+- Pass in `NPM_TOKEN`.
+- Optional: You can specify any NPM tags you'd like to `preserve`.
+
+## Usage
+```yaml
+jobs:
+  job_name:
+    name: Job Name
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: thefrontside/actions/synchronize-npm-tags@master
+      with:
+        preserve: dev beta alpha
+      env:
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+``` -->

--- a/yarn/README.md
+++ b/yarn/README.md
@@ -1,11 +1,5 @@
-<!-- # Synchronize NPM Tags
-`synchronize-npm-tags` is part of our Transparent Publishing workflow and is meant to be triggered `on: delete`. This action will cross-reference the NPM dist-tags with branch names and remove the tags that we no longer need (with the exception of `latest` and any other tag labels that are passed in as the `preserve` argument).
-
-For instance, let's say we have a pull request that published a package with the tag of `foo-bar`. After we merge the pull request and delete the branch, this action will be triggered and see that "foo-bar" exists as a tag but there's no corresponding branch so it will remove that tag from the registry.
-
-## Requirements
-- Pass in `NPM_TOKEN`.
-- Optional: You can specify any NPM tags you'd like to `preserve`.
+# Yarn
+This action is to replace the standard `yarn` command so that the workflow will fail if there are any warnings.
 
 ## Usage
 ```yaml
@@ -15,9 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: thefrontside/actions/synchronize-npm-tags@master
-      with:
-        preserve: dev beta alpha
-      env:
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-``` -->
+    - uses: thefrontside/actions/yarn@v1.8
+```

--- a/yarn/entrypoint.sh
+++ b/yarn/entrypoint.sh
@@ -2,15 +2,15 @@
 set -e
 
 RED='\033[1;31m'
-GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-# WARN
-# warning
-# error
+yarn > stderr.log 2>&1
+yarnoutput="$(cat stderr.log)"
+echo "$yarnoutput"
+warnCount="$(echo $yarnoutput | grep -c -i "warn")"
 
-# check if spell casing has an effect when you filter
-# check if action does yarn, does it persist?
-
-yarn
+if [ $warnCount != "0" ]; then
+  echo -e "${RED}ERROR:${YELLOW} Halting workflow because a warning was detected while installing...${NC}"
+  exit 1
+fi;

--- a/yarn/entrypoint.sh
+++ b/yarn/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# WARN
+# warning
+# error
+
+# check if spell casing has an effect when you filter
+# check if action does yarn, does it persist?
+
+yarn


### PR DESCRIPTION
## Motivation
Currently there is no way of halting a workflow when `yarn install` comes across a warning so I've created a simple action to exit if the output from `yarn` has `warn` somewhere inside its content.