### PR TITLE
Specify python2 for dockerfiles for v1 actions

### DIFF
--- a/publish-pr-preview/Dockerfile
+++ b/publish-pr-preview/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --no-cache git bash git-subtree jq python make g++
+RUN apk add --no-cache git bash git-subtree jq python2 make g++
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/synchronize-with-npm/Dockerfile
+++ b/synchronize-with-npm/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12-alpine
 
-RUN apk add --no-cache git bash git-subtree jq python make g++
+RUN apk add --no-cache git bash git-subtree jq python2 make g++
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
## Motivation

https://github.com/thefrontside/interactors/actions/workflows/release.yml

## Approach

- Deleted the `v1` tag (we should be using `v#` for branches and `v#.#` for tags but I didn't know any better at the time) and pushed `v1.8` (latest) to the `v1` branch. Now if anything breaks, I can create fixes and create PRs against the new `v1` branch.
- Updated the two dockerfiles that were installing `python` to install `python2` instead.
- Built the two images locally successfully.

## TODOs

- [x] Update [interactors #152](https://github.com/thefrontside/interactors/pull/152) to try out the updated dockerfiles directly from this branch
- [x] Once ☝️ works, we can merge this PR and do a manual release of `v1.9` and then update all of our frontside projects that are using the old release action to use `v1.9`