### PR TITLE
Configure workspace as a safe directory

### DIFF
--- a/publish-pr-preview/README.md
+++ b/publish-pr-preview/README.md
@@ -28,9 +28,11 @@ jobs:
     name: Job Name
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Publish PR Preview
-      uses: thefrontside/actions/publish-pr-preview@master
+      uses: thefrontside/actions/publish-pr-preview@v1
       with:
         BEFORE_ALL: npm run prepack-after-install
         NPM_PUBLISH: npm run my-script

--- a/publish-pr-preview/entrypoint.sh
+++ b/publish-pr-preview/entrypoint.sh
@@ -176,6 +176,7 @@ function package_json_finder(){
     done;
   }
   
+  git config --global --add safe.directory /github/workspace
   git checkout $GITHUB_BASE_REF
   git checkout $GITHUB_HEAD_REF
 

--- a/synchronize-npm-tags/README.md
+++ b/synchronize-npm-tags/README.md
@@ -14,8 +14,8 @@ jobs:
     name: Job Name
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: thefrontside/actions/synchronize-npm-tags@master
+    - uses: actions/checkout@v3
+    - uses: thefrontside/actions/synchronize-npm-tags@v1
       with:
         preserve: dev beta alpha
       env:

--- a/synchronize-with-npm/README.md
+++ b/synchronize-with-npm/README.md
@@ -19,9 +19,11 @@ jobs:
     name: Job Name
     runs-on: ubuntu-16.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Syncrhonize with NPM
-      uses: thefrontside/actions/synchronize-with-npm@master
+      uses: thefrontside/actions/synchronize-with-npm@v1
       with:
         BEFORE_ALL: npm run prepack-after-install
         NPM_PUBLISH: npm run my-script

--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -8,6 +8,7 @@ BLUE='\033[1;34m'
 NC='\033[0m'
 
 function git_setup(){
+  git config --global --add safe.directory /github/workspace
   git remote set-url origin https://x-oauth-basic:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
   git fetch origin +refs/heads/*:refs/heads/*
 


### PR DESCRIPTION
## Motivation

Our release workflow suddenly stopped working in [`graphgen`](https://github.com/thefrontside/graphgen) and it looks like it's because of a recent change introduced to git.

## Approach

I followed the workaround explained [here](https://github.com/actions/checkout/issues/766) and submitted the changes as well as upgrade the READMEs.

The typescript version of our actions don't seem affected. I was able to run the new preview action in graphgen without any problems.