### PR TITLE
Remove redundant branch checkout for release

### DIFF
--- a/synchronize-with-npm/entrypoint.sh
+++ b/synchronize-with-npm/entrypoint.sh
@@ -9,12 +9,6 @@ NC='\033[0m'
 
 function git_setup(){
   git config --global --add safe.directory /github/workspace
-  git remote set-url origin https://x-oauth-basic:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-  git fetch origin +refs/heads/*:refs/heads/*
-
-  branch="${GITHUB_REF#*refs\/heads\/}"
-  git checkout $branch
-
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config user.name "$GITHUB_ACTOR"
 }


### PR DESCRIPTION
## Motivation

```
fatal: Refusing to fetch into current branch refs/heads/v0 of non-bare repository
```

We're getting this error in graphgen. If I remember correctly, I think I was fetching and checking out _to the_ main branch because of how checkout `v1` worked. When the action runs, it starts from the main branch anyway so most of the git_setup is no longer ncessary.

## Approach

- Removed fetching and checkout of the main branch