### PR TITLE
workflow to sync the dist if `yarn build` was missed

### DIFF
--- a/.github/workflows/sync-dist.yml
+++ b/.github/workflows/sync-dist.yml
@@ -1,0 +1,33 @@
+name: Dist Update
+
+on:
+  push:
+    branches:
+      - "v[0-9]+"
+
+jobs:
+  dist-update:
+    name: Dist Update Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: volta-cli/action@v3
+      - run: yarn
+      - run: yarn build
+      - name: Open PR If There Are Changes To `dist`
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+          commit-message: service-lockfile-updates
+          branch: dist-updates
+          title: Dist Updates
+          body: |
+            ## Motivation
+
+            Syncing `*/dist` changes as it was not build in a previous commit.
+
+            ## Approach
+
+            A sync was run and the `yarn install` changed the lockfile.


### PR DESCRIPTION
## Motivation

Sometimes `yarn build` is forgotten before a commit and there is not a great way to verify. This will run after a commit to the main branch and open up a new PR if the `dist` is out of sync with the main branch.

